### PR TITLE
fix: remove unsupported --compatibility-date from Wrangler deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -99,7 +99,7 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy dist --project-name=bdiff --compatibility-date=2024-05-15
+          command: pages deploy dist --project-name=bdiff
           
       - name: Notify Slack on Production Deploy Success
         if: success()
@@ -178,7 +178,7 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy dist --project-name=bdiff --compatibility-date=2024-05-15
+          command: pages deploy dist --project-name=bdiff
           
       - name: Notify Slack on Preview Deploy Success
         if: success()


### PR DESCRIPTION
## Problem

GitHub Actions deployment was failing with the error:
```
✘ ERROR Unknown arguments: compatibility-date, compatibilityDate
The process '/usr/local/bin/npx' failed with exit code 1
```

This occurred in the "Deploy to Cloudflare Pages (Production)" step because the `--compatibility-date` argument is not supported in newer versions of Wrangler for the `pages deploy` command.

## Solution

- Removed `--compatibility-date=2024-05-15` argument from both production and preview deployment commands
- The `pages deploy` command in Wrangler v3 uses the project's configured compatibility date instead
- This resolves the deployment pipeline failure while maintaining functionality

## Verification

The fix addresses the specific error message seen in the failed GitHub Actions run:
- Production deployment: Line 102 (fixed)
- Preview deployment: Line 181 (fixed)

## Related Issues

Fixes the GitHub Actions failure reported at: https://github.com/rengotaku/bdiff/actions/runs/17666576569/job/50209249936

🤖 Generated with [Claude Code](https://claude.ai/code)