### PR TITLE
fix: コンテキスト省略ブロックの展開順序バグを修正

### DIFF
--- a/src/components/diff/DiffViewer.tsx
+++ b/src/components/diff/DiffViewer.tsx
@@ -195,7 +195,7 @@ CollapsedLinesRow.displayName = 'CollapsedLinesRow';
  */
 const SideBySideView = memo<{
   rows: SideBySideRow[];
-  onExpandBlock: (index: number) => void;
+  onExpandBlock: (startLine: number) => void;
 }>(({ rows, onExpandBlock }) => (
   <div role="main" aria-label="Side-by-side diff view">
     {/* Header row */}
@@ -212,9 +212,9 @@ const SideBySideView = memo<{
       {rows.map((row, index) =>
         isCollapsedBlock(row) ? (
           <CollapsedLinesRow
-            key={`collapsed-${index}`}
+            key={`collapsed-${row.originalStartLine}`}
             block={row}
-            onExpand={() => onExpandBlock(index)}
+            onExpand={() => onExpandBlock(row.originalStartLine)}
           />
         ) : (
           <SideBySidePairRow
@@ -258,16 +258,16 @@ UnifiedCollapsedRow.displayName = 'UnifiedCollapsedRow';
  */
 const UnifiedPanel = memo<{
   rows: UnifiedRow[];
-  onExpandBlock: (index: number) => void;
+  onExpandBlock: (startLine: number) => void;
 }>(({ rows, onExpandBlock }) => (
   <div className="space-y-2">
     <div className="border rounded-md overflow-visible" role="region" aria-label="Unified diff view">
       {rows.map((row, index) =>
         isUnifiedCollapsedBlock(row) ? (
           <UnifiedCollapsedRow
-            key={`collapsed-${index}`}
+            key={`collapsed-${row.startLine}`}
             block={row}
-            onExpand={() => onExpandBlock(index)}
+            onExpand={() => onExpandBlock(row.startLine)}
           />
         ) : (
           <DiffLineComponent
@@ -296,7 +296,7 @@ export const DiffViewer: React.FC<DiffViewerProps> = memo(({
   enableCharDiff = true,
   contextLines
 }) => {
-  // Track expanded blocks by their original index in filtered rows
+  // Track expanded blocks by their originalStartLine / startLine (stable identifiers)
   const [expandedSideBySideBlocks, setExpandedSideBySideBlocks] = useState<Set<number>>(new Set());
   const [expandedUnifiedBlocks, setExpandedUnifiedBlocks] = useState<Set<number>>(new Set());
 
@@ -326,11 +326,10 @@ export const DiffViewer: React.FC<DiffViewerProps> = memo(({
       return filtered;
     }
 
-    // Re-expand blocks (note: this is a simplified approach)
+    // Re-expand blocks using originalStartLine as stable identifier
     const result: SideBySideRow[] = [];
-    filtered.forEach((row, index) => {
-      if (isCollapsedBlock(row) && expandedSideBySideBlocks.has(index)) {
-        // Expand this block
+    filtered.forEach((row) => {
+      if (isCollapsedBlock(row) && expandedSideBySideBlocks.has(row.originalStartLine)) {
         result.push(...row.lines);
       } else {
         result.push(row);
@@ -390,11 +389,10 @@ export const DiffViewer: React.FC<DiffViewerProps> = memo(({
       return filtered;
     }
 
-    // Re-expand blocks
+    // Re-expand blocks using startLine as stable identifier
     const result: UnifiedRow[] = [];
-    filtered.forEach((row, index) => {
-      if (isUnifiedCollapsedBlock(row) && expandedUnifiedBlocks.has(index)) {
-        // Expand this block
+    filtered.forEach((row) => {
+      if (isUnifiedCollapsedBlock(row) && expandedUnifiedBlocks.has(row.startLine)) {
         result.push(...row.lines);
       } else {
         result.push(row);


### PR DESCRIPTION
## Summary

- 省略ブロック（x lines hidden）を上→下の順で展開すると下のブロックが展開できないバグを修正
- 展開状態の管理キーを配列インデックスから `originalStartLine` / `startLine` に変更し、展開によるインデックスのズレを解消

Closes #45

## 原因

`SideBySideView` / `UnifiedPanel` で `rows.map((row, index)` の `index` を `onExpandBlock` に渡していたが、上のブロックを展開すると `rows` の要素数が増え、下のブロックのインデックスがズレて `filtered` 配列のインデックスと一致しなくなっていた。

## 変更内容

`DiffViewer.tsx` のみ:
- `expandedSideBySideBlocks` のキーを配列index → `CollapsedBlock.originalStartLine` に変更
- `expandedUnifiedBlocks` のキーを配列index → `UnifiedCollapsedBlock.startLine` に変更
- `SideBySideView` / `UnifiedPanel` の `onExpand` で渡す値を安定した識別子に変更
- React の `key` も `originalStartLine` / `startLine` ベースに変更

## Test plan

- [x] `npx tsc --noEmit` 型チェック通過
- [x] `npx vitest run` 全116テスト通過
- [ ] 手動確認: 上→下の順で省略ブロックを展開できること
- [ ] 手動確認: 下→上の順でも引き続き動作すること
- [ ] Side-by-side / Unified 両モードで確認