### PR TITLE
feat: HTMLエクスポートにコンテキスト行省略機能を追加

### DIFF
--- a/src/components/diff/FileComparisonPanel.tsx
+++ b/src/components/diff/FileComparisonPanel.tsx
@@ -83,6 +83,7 @@ export const FileComparisonPanel: React.FC<FileComparisonPanelProps> = ({
               diffResult={diffResult}
               originalFile={originalFile || null}
               modifiedFile={modifiedFile || null}
+              collapseUnchanged={collapseUnchanged}
               variant="ghost"
               size="sm"
               onSuccess={onExportSuccess}

--- a/src/components/export/HTMLExportButton.tsx
+++ b/src/components/export/HTMLExportButton.tsx
@@ -12,6 +12,8 @@ interface HTMLExportButtonProps {
   originalFile: FileInfo | null;
   /** Modified file information */
   modifiedFile: FileInfo | null;
+  /** Collapse unchanged lines (inherited from main view settings) */
+  collapseUnchanged?: boolean;
   /** Button variant */
   variant?: 'primary' | 'secondary' | 'ghost';
   /** Button size */
@@ -31,6 +33,7 @@ export const HTMLExportButton: React.FC<HTMLExportButtonProps> = ({
   diffResult,
   originalFile,
   modifiedFile,
+  collapseUnchanged = true,
   variant = 'ghost',
   size = 'sm',
   className,
@@ -79,6 +82,7 @@ export const HTMLExportButton: React.FC<HTMLExportButtonProps> = ({
         ...options,
         originalFile,
         modifiedFile,
+        collapseUnchanged,
       };
 
       // Export and download using new ExportService
@@ -115,6 +119,7 @@ export const HTMLExportButton: React.FC<HTMLExportButtonProps> = ({
         ...options,
         originalFile,
         modifiedFile,
+        collapseUnchanged,
       };
 
       // Export and preview using new ExportService

--- a/src/components/export/HTMLExportDialog.tsx
+++ b/src/components/export/HTMLExportDialog.tsx
@@ -18,6 +18,7 @@ const DEFAULT_HTML_EXPORT_OPTIONS: Required<HtmlExportOptions> = {
   filename: undefined as any,
   originalFile: undefined as any,
   modifiedFile: undefined as any,
+  collapseUnchanged: false,
 };
 
 interface HTMLExportDialogProps {

--- a/src/services/export/renderers/HTMLRenderer.ts
+++ b/src/services/export/renderers/HTMLRenderer.ts
@@ -4,6 +4,7 @@
  */
 
 import type { DiffLine, CharSegment, LineWithSegments } from '../../../types/types';
+import { isCollapsedBlock, isUnifiedCollapsedBlock } from '../../../types/types';
 import type { HtmlExportOptions } from '../types';
 import { BaseRenderer } from './BaseRenderer';
 import { TAILWIND_CSS } from '../../tailwindEmbedded';
@@ -23,6 +24,7 @@ const DEFAULT_OPTIONS: Required<HtmlExportOptions> = {
   filename: undefined as any,
   originalFile: undefined as any,
   modifiedFile: undefined as any,
+  collapseUnchanged: false,
 };
 
 /**
@@ -205,9 +207,22 @@ ${this.getEmbeddedCSS(opts.theme)}
 
     // Use LinePairingService to get lines with character segments
     const pairedLines = LinePairingService.pairForUnifiedView(lines, true);
-    const lineElements = pairedLines.map(lineWithSegments =>
-      this.renderDiffLineWithSegments(lineWithSegments, options)
-    ).join('\n');
+
+    // Apply context filtering if collapseUnchanged is enabled
+    const rows = options.collapseUnchanged
+      ? LinePairingService.applyContextFilterUnified(pairedLines, 3)
+      : pairedLines;
+
+    const lineElements = rows.map(row => {
+      if (isUnifiedCollapsedBlock(row)) {
+        const colSpan = options.includeLineNumbers ? 3 : 2;
+        return `
+            <tr class="collapsed-row">
+              <td colspan="${colSpan}" class="collapsed-cell">⋯ ${row.count} lines hidden ⋯</td>
+            </tr>`;
+      }
+      return this.renderDiffLineWithSegments(row, options);
+    }).join('\n');
 
     return `
       <div class="diff-table-container">
@@ -233,9 +248,18 @@ ${this.getEmbeddedCSS(opts.theme)}
     // Use LinePairingService to get properly paired lines (same as screen display)
     const pairs = LinePairingService.pairLinesForSideBySide(lines, true);
 
-    const pairRows = pairs.map(pair => {
-      const originalCell = this.renderSideBySideCell(pair.original, options, 'original');
-      const modifiedCell = this.renderSideBySideCell(pair.modified, options, 'modified');
+    // Apply context filtering if collapseUnchanged is enabled
+    const rows = options.collapseUnchanged
+      ? LinePairingService.applyContextFilter(pairs, 3)
+      : pairs;
+
+    const colCount = options.includeLineNumbers ? 6 : 4;
+    const pairRows = rows.map(row => {
+      if (isCollapsedBlock(row)) {
+        return `<tr class="side-by-side-row collapsed-row"><td colspan="${colCount}" class="collapsed-cell">⋯ ${row.count} lines hidden ⋯</td></tr>`;
+      }
+      const originalCell = this.renderSideBySideCell(row.original, options, 'original');
+      const modifiedCell = this.renderSideBySideCell(row.modified, options, 'modified');
       return `<tr class="side-by-side-row">${originalCell}${modifiedCell}</tr>`;
     }).join('\n');
 
@@ -659,6 +683,19 @@ ${this.hasCharHighlighting ? `
       color: #166534;
     }
 ` : ''}
+    /* Collapsed rows */
+    .collapsed-row {
+      background: ${isLight ? '#f3f4f6' : '#374151'};
+    }
+
+    .collapsed-cell {
+      text-align: center;
+      padding: 6px 8px;
+      font-size: 12px;
+      color: ${isLight ? '#6b7280' : '#9ca3af'};
+      cursor: default;
+    }
+
     /* Side-by-side layout */
     .side-by-side-container {
       overflow-x: auto;

--- a/src/services/export/renderers/MarkdownRenderer.ts
+++ b/src/services/export/renderers/MarkdownRenderer.ts
@@ -20,6 +20,7 @@ const DEFAULT_OPTIONS: Required<MarkdownExportOptions> = {
   filename: undefined as any,
   originalFile: undefined as any,
   modifiedFile: undefined as any,
+  collapseUnchanged: false,
 };
 
 /**

--- a/src/services/export/renderers/PlainTextRenderer.ts
+++ b/src/services/export/renderers/PlainTextRenderer.ts
@@ -20,6 +20,7 @@ const DEFAULT_OPTIONS: Required<PlainTextExportOptions> = {
   filename: undefined as any,
   originalFile: undefined as any,
   modifiedFile: undefined as any,
+  collapseUnchanged: false,
 };
 
 /**

--- a/src/services/export/types.ts
+++ b/src/services/export/types.ts
@@ -28,6 +28,8 @@ export interface BaseExportOptions {
   originalFile?: FileInfo;
   /** Modified file information */
   modifiedFile?: FileInfo;
+  /** Collapse unchanged lines (show only context around changes) */
+  collapseUnchanged?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary

- 本画面の `collapseUnchanged` 設定をHTMLエクスポートに引き継ぎ、省略ブロック（「⋯ N lines hidden ⋯」）を出力
- Side-by-side / Unified 両モードに対応
- エクスポートダイアログへの設定追加は不要（本画面の設定をそのまま使用）

Closes #47

## 変更内容

- `BaseExportOptions` に `collapseUnchanged` プロパティ追加
- `HTMLRenderer` の unified/side-by-side 生成で `LinePairingService.applyContextFilter` / `applyContextFilterUnified` を適用
- collapsed 行のCSS追加
- `FileComparisonPanel` → `HTMLExportButton` → `ExportService` へ設定値を伝搬

## Test plan

- [x] `npx tsc --noEmit` 型チェック通過
- [x] `npx vitest run` 全116テスト通過
- [ ] 手動確認: collapseUnchanged=true でエクスポートしたHTMLに省略行が含まれること
- [ ] 手動確認: collapseUnchanged=false でエクスポートしたHTMLに全行が含まれること
- [ ] Side-by-side / Unified 両モードで確認
- [ ] プレビュー機能でも省略が反映されること