### PR TITLE
fix: エクスポートファイル名の生成ロジックを改善

### DIFF
--- a/src/services/export/renderers/BaseRenderer.ts
+++ b/src/services/export/renderers/BaseRenderer.ts
@@ -30,16 +30,23 @@ export abstract class BaseRenderer implements IRenderer {
    */
   generateFilename(originalFile?: FileInfo, modifiedFile?: FileInfo): string {
     const timestamp = new Date().toISOString().split('T')[0]; // YYYY-MM-DD
+    const fallback = this.sanitizeFilename(`diff_${timestamp}${this.getFileExtension()}`);
 
     if (originalFile?.name && modifiedFile?.name) {
-      const originalName = this.stripExtension(originalFile.name);
-      const modifiedName = this.stripExtension(modifiedFile.name);
+      const originalName = this.truncateName(this.sanitizeFilename(this.stripExtension(originalFile.name)));
+      const modifiedName = this.truncateName(this.sanitizeFilename(this.stripExtension(modifiedFile.name)));
+
+      // Fall back if sanitized names are empty or only underscores
+      if (!this.isMeaningfulName(originalName) || !this.isMeaningfulName(modifiedName)) {
+        return fallback;
+      }
+
       return this.sanitizeFilename(
         `${originalName}_vs_${modifiedName}_diff_${timestamp}${this.getFileExtension()}`
       );
     }
 
-    return this.sanitizeFilename(`diff_${timestamp}${this.getFileExtension()}`);
+    return fallback;
   }
 
   /**
@@ -92,7 +99,22 @@ export abstract class BaseRenderer implements IRenderer {
   protected sanitizeFilename(filename: string): string {
     return filename
       .replace(/[^a-zA-Z0-9._-]/g, '_')
-      .replace(/_{2,}/g, '_');
+      .replace(/_{2,}/g, '_')
+      .replace(/^_+|_+$/g, '');
+  }
+
+  /**
+   * Truncate a name to max length for filename safety
+   */
+  private truncateName(name: string, maxLength: number = 20): string {
+    return name.length > maxLength ? name.slice(0, maxLength) : name;
+  }
+
+  /**
+   * Check if a sanitized name contains meaningful characters (not just underscores/empty)
+   */
+  private isMeaningfulName(name: string): boolean {
+    return name.replace(/_/g, '').length > 0;
   }
 
   /**

--- a/src/services/htmlExportService.ts
+++ b/src/services/htmlExportService.ts
@@ -631,16 +631,29 @@ ${this.getEmbeddedCSS(opts.theme)}
    */
   static generateFilename(originalFile: FileInfo, modifiedFile: FileInfo): string {
     const timestamp = new Date().toISOString().split('T')[0]; // YYYY-MM-DD format
-    const originalName = originalFile.name.replace(/\.[^/.]+$/, ''); // Remove extension
-    const modifiedName = modifiedFile.name.replace(/\.[^/.]+$/, ''); // Remove extension
-    
-    return `${originalName}_vs_${modifiedName}_diff_${timestamp}.html`;
+    const fallback = `diff_${timestamp}.html`;
+    const originalName = this.truncateName(this.sanitizeFilename(originalFile.name.replace(/\.[^/.]+$/, '')));
+    const modifiedName = this.truncateName(this.sanitizeFilename(modifiedFile.name.replace(/\.[^/.]+$/, '')));
+
+    if (!this.isMeaningfulName(originalName) || !this.isMeaningfulName(modifiedName)) {
+      return fallback;
+    }
+
+    return this.sanitizeFilename(`${originalName}_vs_${modifiedName}_diff_${timestamp}.html`);
   }
 
   /**
    * Sanitize filename for safe download
    */
   private static sanitizeFilename(filename: string): string {
-    return filename.replace(/[^a-zA-Z0-9._-]/g, '_').replace(/_{2,}/g, '_');
+    return filename.replace(/[^a-zA-Z0-9._-]/g, '_').replace(/_{2,}/g, '_').replace(/^_+|_+$/g, '');
+  }
+
+  private static truncateName(name: string, maxLength: number = 20): string {
+    return name.length > maxLength ? name.slice(0, maxLength) : name;
+  }
+
+  private static isMeaningfulName(name: string): boolean {
+    return name.replace(/_/g, '').length > 0;
   }
 }


### PR DESCRIPTION
## Summary

- テキスト直接入力時にファイル名が `_vs__diff_2026-03-30.html` のように不適切になる問題を修正
- sanitize後に意味のない名前（空や `_` のみ）の場合は `diff_2026-03-30.html` にフォールバック
- 長いファイル名は各20文字に切り詰め、OS/ブラウザのファイル名長制限を考慮

Closes #48

## 変更内容

### `BaseRenderer.ts`
- `generateFilename()`: 各ファイル名をsanitize→truncate後に `isMeaningfulName()` チェック
- `sanitizeFilename()`: 先頭・末尾のアンダースコアを除去
- `truncateName()`: 各ファイル名を20文字に切り詰め
- `isMeaningfulName()`: アンダースコア以外の文字が含まれるか判定

### `htmlExportService.ts`（レガシー版）
- 同じロジックを適用

## Test plan

- [x] `npx tsc --noEmit` 型チェック通過
- [x] `npx vitest run` 全116テスト通過
- [ ] 手動確認: テキスト入力で比較 → エクスポート → ファイル名が `diff_2026-03-31.html`
- [ ] 手動確認: ファイルアップロードで比較 → エクスポート → ファイル名が `file1_vs_file2_diff_2026-03-31.html`
- [ ] 手動確認: 長いファイル名 → 切り詰めが効くこと