### PR TITLE
fix: Side-by-side表示で同一行の変更が分離表示される問題を修正

### DIFF
--- a/src/services/__tests__/linePairingService.test.ts
+++ b/src/services/__tests__/linePairingService.test.ts
@@ -161,19 +161,17 @@ describe('LinePairingService', () => {
         expect(result[0].modified?.line.content).toContain('すでに初回アート監修OK済み');
       });
 
-      it('全く異なる行は別々に出力される（インターリーブなし）', () => {
+      it('全く異なる行でも同一ブロック内なら位置ベースでペアリングされる', () => {
         const lines: DiffLine[] = [
           createLine('これは削除される行です', 'removed', 1),
           createLine('ABCDEFGHIJKLMNOP', 'added', 2),
         ];
         const result = LinePairingService.pairLinesForSideBySide(lines, false);
 
-        // 類似していない行はペアリングされず、別々に出力される
-        expect(result).toHaveLength(2);
+        // 同一ブロック内のremoved/addedは位置ベースで横並びにペアリングされる
+        expect(result).toHaveLength(1);
         expect(result[0].original?.line.content).toBe('これは削除される行です');
-        expect(result[0].modified).toBeNull();
-        expect(result[1].original).toBeNull();
-        expect(result[1].modified?.line.content).toBe('ABCDEFGHIJKLMNOP');
+        expect(result[0].modified?.line.content).toBe('ABCDEFGHIJKLMNOP');
       });
 
       it('複数の候補から最も類似度の高いペアを選択', () => {

--- a/src/services/linePairingService.ts
+++ b/src/services/linePairingService.ts
@@ -552,7 +552,7 @@ export class LinePairingService {
       return pairs;
     }
 
-    // Use content-based matching
+    // Use content-based matching for reordering similar lines
     const matches = this.matchByContent(removedLines, addedLines);
 
     // Create index mappings for matched pairs
@@ -567,16 +567,33 @@ export class LinePairingService {
     // Track which lines have been output
     const usedAdded = new Set<number>();
 
-    // Process removed lines in order, matching by content similarity only
+    // Positional index for fallback pairing of unmatched lines
+    let nextUnmatchedAddedIdx = 0;
+
+    // Process removed lines in order
     for (let removedIdx = 0; removedIdx < removedLines.length; removedIdx++) {
       const removed = removedLines[removedIdx];
 
-      // Check for content match
+      // Check for content-similarity match first
+      let added: DiffLine | undefined;
       if (removedToAdded.has(removedIdx)) {
         const addedIdx = removedToAdded.get(removedIdx)!;
-        const added = addedLines[addedIdx];
+        added = addedLines[addedIdx];
         usedAdded.add(addedIdx);
+      } else {
+        // Fallback: pair positionally with next unused added line
+        while (nextUnmatchedAddedIdx < addedLines.length &&
+               (usedAdded.has(nextUnmatchedAddedIdx) || addedToRemoved.has(nextUnmatchedAddedIdx))) {
+          nextUnmatchedAddedIdx++;
+        }
+        if (nextUnmatchedAddedIdx < addedLines.length) {
+          added = addedLines[nextUnmatchedAddedIdx];
+          usedAdded.add(nextUnmatchedAddedIdx);
+          nextUnmatchedAddedIdx++;
+        }
+      }
 
+      if (added) {
         // Output matched pair with char diff if applicable
         if (enableCharDiff && CharDiffService.shouldShowCharDiff(removed.content, added.content)) {
           const { originalSegments, modifiedSegments } = CharDiffService.calculateCharDiff(
@@ -594,12 +611,12 @@ export class LinePairingService {
           });
         }
       } else {
-        // No match - output removed line alone (will be matched in second pass if possible)
+        // No added line available - output removed line alone
         pairs.push({ original: { line: removed }, modified: null });
       }
     }
 
-    // Output remaining added lines (will be matched in second pass if possible)
+    // Output remaining added lines that weren't paired
     for (let addedIdx = 0; addedIdx < addedLines.length; addedIdx++) {
       if (!usedAdded.has(addedIdx)) {
         pairs.push({ original: null, modified: { line: addedLines[addedIdx] } });


### PR DESCRIPTION
## Summary
- Side-by-side表示で、同一ブロック内のremoved/added行が類似度閾値(0.5)未満でも位置ベースでペアリングされるよう修正
- 「あいうえお→かきくけこ」のような完全に異なる内容でも同じ行に横並び表示される
- 類似度が高い行は引き続き内容ベースで最適マッチングされる（既存動作を維持）

Closes #55

## 変更内容
- `LinePairingService.matchBlockLines()`: 類似度マッチに失敗した行を位置ベースで未使用のadded行とペアリングするフォールバック追加
- テスト更新: 全く異なる行でも同一ブロック内なら横並びペアリングされることを検証

## Test plan
- [x] 既存テスト116件全パス
- [x] 「あいうえお」vs「かきくけこ」でSide-by-side表示が同一行に並ぶことを確認
- [x] 複数行の変更ブロックで類似行が正しくマッチングされることを確認
- [x] Unified表示に影響がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)