### PR TITLE
fix: トップページからサブタイトルを削除

### DIFF
--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -213,7 +213,6 @@ export const HomePage: React.FC = () => {
   return (
     <ContentLayout
       title={t('app.title')}
-      subtitle={t('app.subtitle')}
     >
       <div className="space-y-8">
         {/* File Upload Areas */}


### PR DESCRIPTION
## Summary

トップページの「変更を美しく可視化」サブタイトルを削除。

- `HomePage.tsx` の `ContentLayout` から `subtitle` prop を除去
- 翻訳キー `app.subtitle` は About ページ等で使用される可能性があるため残置

## Test plan

- [ ] トップページにサブタイトルが表示されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)