### PR TITLE
fix: Side-by-side表示で長い行の横スクロール対応 (#78)

### DIFF
--- a/src/components/diff/DiffViewer.tsx
+++ b/src/components/diff/DiffViewer.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo, memo, useState, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { getLineClassName, getPrefixSymbol } from '../../utils/diffRendering';
-import type { DiffLine, ViewMode, CharSegment, LineWithSegments, LinePair, SideBySideRow, UnifiedRow } from '../../types/types';
+import type { DiffLine, ViewMode, CharSegment, LineWithSegments, SideBySideRow, UnifiedRow } from '../../types/types';
 import { isCollapsedBlock, isUnifiedCollapsedBlock } from '../../types/types';
 import { LinePairingService } from '../../services/linePairingService';
 
@@ -144,56 +144,33 @@ SideBySideCell.displayName = 'SideBySideCell';
  * Side-by-side pair row component
  * Renders original and modified lines in the same grid row for height synchronization
  */
-const SideBySidePairRow = memo<{
-  pair: LinePair;
-  index: number;
-}>(({ pair, index }) => (
-  <div className="grid grid-cols-2 items-stretch">
-    <div className="border-r border-gray-200 min-h-full">
-      <SideBySideCell item={pair.original} index={index} side="original" />
-    </div>
-    <div className="min-h-full">
-      <SideBySideCell item={pair.modified} index={index} side="modified" />
-    </div>
-  </div>
-));
-
-SideBySidePairRow.displayName = 'SideBySidePairRow';
-
 /**
- * Collapsed lines row component (GitHub-style)
- * Shows a clickable row that expands to reveal hidden lines
+ * Collapsed line placeholder for one side of a collapsed row
  */
-const CollapsedLinesRow = memo<{
-  onExpand: () => void;
+const CollapsedLineCell = memo<{
   collapsedText: string;
   expandLabel: string;
-}>(({ onExpand, collapsedText, expandLabel }) => (
+  onExpand: () => void;
+  hasBorderRight?: boolean;
+}>(({ collapsedText, expandLabel, onExpand, hasBorderRight }) => (
   <div
-    className="grid grid-cols-2 cursor-pointer hover:bg-blue-50 transition-colors"
+    className={`bg-gray-100 py-1 px-4 text-center cursor-pointer hover:bg-blue-50 transition-colors ${hasBorderRight ? 'border-r border-gray-200' : ''}`}
     onClick={onExpand}
     role="button"
     tabIndex={0}
     onKeyDown={(e) => e.key === 'Enter' && onExpand()}
     aria-label={expandLabel}
   >
-    <div className="border-r border-gray-200 bg-gray-100 py-1 px-4 text-center">
-      <span className="text-xs text-gray-500">
-        {collapsedText}
-      </span>
-    </div>
-    <div className="bg-gray-100 py-1 px-4 text-center">
-      <span className="text-xs text-gray-500">
-        {collapsedText}
-      </span>
-    </div>
+    <span className="text-xs text-gray-500">
+      {collapsedText}
+    </span>
   </div>
 ));
 
-CollapsedLinesRow.displayName = 'CollapsedLinesRow';
+CollapsedLineCell.displayName = 'CollapsedLineCell';
 
 /**
- * Side-by-side view with synchronized line heights
+ * Side-by-side view with independent horizontal scrolling per column
  */
 const SideBySideView = memo<{
   rows: SideBySideRow[];
@@ -204,34 +181,60 @@ const SideBySideView = memo<{
   expandLinesText: (count: number) => string;
 }>(({ rows, onExpandBlock, headerOriginal, headerModified, collapsedLinesText, expandLinesText }) => (
   <div role="main" aria-label="Side-by-side diff view" className="side-by-side-view">
-    {/* Header row */}
-    <div className="grid grid-cols-2 mb-2">
-      <div className="px-4">
-        <div className="font-medium text-sm text-gray-700">{headerOriginal}</div>
+    <div className="grid grid-cols-2">
+      {/* Left column (Original) */}
+      <div className="border-r border-gray-200">
+        <div className="px-4 mb-2">
+          <div className="font-medium text-sm text-gray-700">{headerOriginal}</div>
+        </div>
+        <div className="overflow-x-auto">
+          <div className="min-w-fit">
+            {rows.map((row, index) =>
+              isCollapsedBlock(row) ? (
+                <CollapsedLineCell
+                  key={`collapsed-l-${row.originalStartLine}`}
+                  collapsedText={collapsedLinesText(row.count)}
+                  expandLabel={expandLinesText(row.count)}
+                  onExpand={() => onExpandBlock(row.originalStartLine)}
+                />
+              ) : (
+                <SideBySideCell
+                  key={`pair-l-${index}`}
+                  item={row.original}
+                  index={index}
+                  side="original"
+                />
+              )
+            )}
+          </div>
+        </div>
       </div>
-      <div className="px-4">
-        <div className="font-medium text-sm text-gray-700">{headerModified}</div>
-      </div>
-    </div>
-    {/* Line pairs */}
-    <div className="overflow-x-auto">
-      <div className="min-w-fit">
-        {rows.map((row, index) =>
-          isCollapsedBlock(row) ? (
-            <CollapsedLinesRow
-              key={`collapsed-${row.originalStartLine}`}
-              onExpand={() => onExpandBlock(row.originalStartLine)}
-              collapsedText={collapsedLinesText(row.count)}
-              expandLabel={expandLinesText(row.count)}
-            />
-          ) : (
-            <SideBySidePairRow
-              key={`pair-${index}`}
-              pair={row}
-              index={index}
-            />
-          )
-        )}
+      {/* Right column (Modified) */}
+      <div>
+        <div className="px-4 mb-2">
+          <div className="font-medium text-sm text-gray-700">{headerModified}</div>
+        </div>
+        <div className="overflow-x-auto">
+          <div className="min-w-fit">
+            {rows.map((row, index) =>
+              isCollapsedBlock(row) ? (
+                <CollapsedLineCell
+                  key={`collapsed-r-${row.originalStartLine}`}
+                  collapsedText={collapsedLinesText(row.count)}
+                  expandLabel={expandLinesText(row.count)}
+                  onExpand={() => onExpandBlock(row.originalStartLine)}
+                />
+              ) : (
+                <SideBySideCell
+                  key={`pair-r-${index}`}
+                  item={row.modified}
+                  index={index}
+                  side="modified"
+                />
+              )
+            )}
+          </div>
+        </div>
       </div>
     </div>
   </div>

--- a/src/components/diff/DiffViewer.tsx
+++ b/src/components/diff/DiffViewer.tsx
@@ -149,10 +149,10 @@ const SideBySidePairRow = memo<{
   index: number;
 }>(({ pair, index }) => (
   <div className="grid grid-cols-2 items-stretch">
-    <div className="border-r border-gray-200 min-h-full overflow-x-auto">
+    <div className="border-r border-gray-200 min-h-full">
       <SideBySideCell item={pair.original} index={index} side="original" />
     </div>
-    <div className="min-h-full overflow-x-auto">
+    <div className="min-h-full">
       <SideBySideCell item={pair.modified} index={index} side="modified" />
     </div>
   </div>
@@ -214,23 +214,25 @@ const SideBySideView = memo<{
       </div>
     </div>
     {/* Line pairs */}
-    <div className="overflow-visible">
-      {rows.map((row, index) =>
-        isCollapsedBlock(row) ? (
-          <CollapsedLinesRow
-            key={`collapsed-${row.originalStartLine}`}
-            onExpand={() => onExpandBlock(row.originalStartLine)}
-            collapsedText={collapsedLinesText(row.count)}
-            expandLabel={expandLinesText(row.count)}
-          />
-        ) : (
-          <SideBySidePairRow
-            key={`pair-${index}`}
-            pair={row}
-            index={index}
-          />
-        )
-      )}
+    <div className="overflow-x-auto">
+      <div className="min-w-fit">
+        {rows.map((row, index) =>
+          isCollapsedBlock(row) ? (
+            <CollapsedLinesRow
+              key={`collapsed-${row.originalStartLine}`}
+              onExpand={() => onExpandBlock(row.originalStartLine)}
+              collapsedText={collapsedLinesText(row.count)}
+              expandLabel={expandLinesText(row.count)}
+            />
+          ) : (
+            <SideBySidePairRow
+              key={`pair-${index}`}
+              pair={row}
+              index={index}
+            />
+          )
+        )}
+      </div>
     </div>
   </div>
 ));

--- a/src/components/diff/DiffViewer.tsx
+++ b/src/components/diff/DiffViewer.tsx
@@ -149,10 +149,10 @@ const SideBySidePairRow = memo<{
   index: number;
 }>(({ pair, index }) => (
   <div className="grid grid-cols-2 items-stretch">
-    <div className="border-r border-gray-200 min-h-full">
+    <div className="border-r border-gray-200 min-h-full overflow-x-auto">
       <SideBySideCell item={pair.original} index={index} side="original" />
     </div>
-    <div className="min-h-full">
+    <div className="min-h-full overflow-x-auto">
       <SideBySideCell item={pair.modified} index={index} side="modified" />
     </div>
   </div>
@@ -203,7 +203,7 @@ const SideBySideView = memo<{
   collapsedLinesText: (count: number) => string;
   expandLinesText: (count: number) => string;
 }>(({ rows, onExpandBlock, headerOriginal, headerModified, collapsedLinesText, expandLinesText }) => (
-  <div role="main" aria-label="Side-by-side diff view">
+  <div role="main" aria-label="Side-by-side diff view" className="side-by-side-view">
     {/* Header row */}
     <div className="grid grid-cols-2 mb-2">
       <div className="px-4">

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -35,9 +35,17 @@
     @apply mx-auto px-4 sm:px-6 lg:px-8;
   }
 
-  /* Diff text wrapping - single comprehensive rule */
+  /* Diff text wrapping - default rule for unified view */
   .diff-line-text {
     overflow-wrap: anywhere;
     word-break: break-all;
+  }
+
+  /* Side-by-side view: no wrapping, horizontal scroll instead */
+  .side-by-side-view .diff-line-text,
+  .side-by-side-view .font-mono {
+    white-space: pre;
+    overflow-wrap: normal;
+    word-break: normal;
   }
 }


### PR DESCRIPTION
## Summary

- Side-by-side表示で長い行が折り返されることによる左右の行高さ不一致を修正
- 折り返しを無効化し、横スクロールで表示するように変更
- Unified表示では従来通り折り返しを維持

## 変更内容

| ファイル | 内容 |
|---------|------|
| `src/components/diff/DiffViewer.tsx` | Side-by-sideコンテナに `side-by-side-view` クラスと `overflow-x: auto` を追加 |
| `src/styles/global.css` | `.side-by-side-view` 内の `diff-line-text` で `white-space: pre` を適用 |

## Before / After

**Before**: 長い行が折り返されて左右の高さがズレる
**After**: 折り返しなし + 横スクロールで左右の高さが一致

## Test plan

- [ ] Side-by-side表示で長い行が横スクロールで表示されること
- [ ] 左右の行高さが一致していること
- [ ] Unified表示では従来通り折り返しが機能すること
- [ ] Issue #78 の再現ケース（改行位置の違う英文）で確認

Closes #78