### PR TITLE
fix: 頻出構造行の遠隔マッチング防止とmodified統計修正 (#97)

### DIFF
--- a/src/__tests__/services/diffService.test.ts
+++ b/src/__tests__/services/diffService.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import { DiffService } from '../../services/diffService';
+import type { ComparisonOptions } from '../../types/types';
+
+const defaultOptions: ComparisonOptions = {
+  sortLines: false,
+  ignoreCase: false,
+  ignoreWhitespace: false,
+  ignoreTrailingNewlines: false,
+  enableCharDiff: false,
+};
+
+describe('DiffService', () => {
+  describe('calculateDiff - 基本動作', () => {
+    it('同一テキストの差分は unchanged のみ', () => {
+      const text = 'line1\nline2\nline3';
+      const result = DiffService.calculateDiff(text, text, defaultOptions);
+      expect(result.stats.added).toBe(0);
+      expect(result.stats.removed).toBe(0);
+      expect(result.stats.modified).toBe(0);
+      expect(result.stats.unchanged).toBe(3);
+    });
+
+    it('完全に異なるテキストの差分', () => {
+      const original = 'AAA\nBBB';
+      const modified = 'CCC\nDDD';
+      const result = DiffService.calculateDiff(original, modified, defaultOptions);
+      expect(result.stats.removed).toBe(2);
+      expect(result.stats.added).toBe(2);
+      expect(result.stats.modified).toBe(0);
+    });
+  });
+
+  describe('calculateDiff - modified 統計（issue #97）', () => {
+    it('enableCharDiff=false の場合、modified は常に 0', () => {
+      const original = 'hello world\nfoo bar\nbaz';
+      const modified = 'hello there\nfoo baz\nbaz';
+      const result = DiffService.calculateDiff(original, modified, {
+        ...defaultOptions,
+        enableCharDiff: false,
+      });
+      expect(result.stats.modified).toBe(0);
+    });
+
+    it('enableCharDiff=true で類似行ペアが存在する場合、modified = 1', () => {
+      // 末尾1語だけ変わった行（高類似度 → char diff 対象）
+      const original = 'hello world\nunchanged line';
+      const modified = 'hello there\nunchanged line';
+      const result = DiffService.calculateDiff(original, modified, {
+        ...defaultOptions,
+        enableCharDiff: true,
+      });
+      // 'hello world' と 'hello there' は類似 → modified=1, removed=0, added=0
+      expect(result.stats.modified).toBe(1);
+      expect(result.stats.removed).toBe(0);
+      expect(result.stats.added).toBe(0);
+      expect(result.stats.unchanged).toBe(1);
+    });
+
+    it('enableCharDiff=true で完全に異なる行は modified にならない', () => {
+      // 類似度が低い（0.6未満）行は char diff 対象外 → removed/added のまま
+      const original = 'AAAAAAAAAAA\nunchanged';
+      const modified = 'ZZZZZZZZZZZ\nunchanged';
+      const result = DiffService.calculateDiff(original, modified, {
+        ...defaultOptions,
+        enableCharDiff: true,
+      });
+      expect(result.stats.modified).toBe(0);
+      expect(result.stats.removed).toBe(1);
+      expect(result.stats.added).toBe(1);
+    });
+
+    it('enableCharDiff=true で統計の合計は全行数に等しい', () => {
+      const original = 'line one\nline two\nline three\ncommon line';
+      const modified = 'line 1\nline 2\nline three\ncommon line';
+      const result = DiffService.calculateDiff(original, modified, {
+        ...defaultOptions,
+        enableCharDiff: true,
+      });
+      const total = result.stats.added + result.stats.removed +
+                    result.stats.modified * 2 + result.stats.unchanged;
+      expect(total).toBe(result.lines.length);
+    });
+  });
+});

--- a/src/services/__tests__/linePairingService.test.ts
+++ b/src/services/__tests__/linePairingService.test.ts
@@ -423,7 +423,85 @@ describe('LinePairingService', () => {
     });
 
     // ========================================
-    // F. パフォーマンス考慮
+    // F. コンテキストレス行の遠隔マッチング防止（issue #97）
+    // ========================================
+    describe('コンテキストレス行の遠隔マッチング防止', () => {
+      it('空行は遠隔マッチングの候補にならない', () => {
+        // removed block: 有意なテキスト行 + 空行（純粋な削除ブロック）
+        // added block: 別箇所の空行（純粋な追加ブロック）
+        // unchanged で区切られた2つのブロックを模擬
+        const lines: DiffLine[] = [
+          createLine('削除される有意な行', 'removed', 1),
+          createLine('', 'removed', 2),  // 空行
+          createLine('変更なし行', 'unchanged', 3),
+          createLine('', 'added', 4),    // 別箇所の空行 - 遠隔マッチングされてはいけない
+          createLine('追加される有意な行', 'added', 5),
+        ];
+        const result = LinePairingService.pairLinesForSideBySide(lines, false);
+
+        // 空行のremoved（index 1）は空行のadded（index 3）と遠隔マッチングされてはいけない
+        const emptyRemovedPair = result.find(
+          p => p.original?.line.content === '' && p.original?.line.type === 'removed'
+        );
+        // 空行は単独（modified=null）のままであるべき
+        expect(emptyRemovedPair?.modified).toBeNull();
+      });
+
+      it('閉じ括弧 } は遠隔マッチングの候補にならない', () => {
+        const lines: DiffLine[] = [
+          createLine('削除されるコードブロック', 'removed', 1),
+          createLine('}', 'removed', 2),  // 閉じ括弧
+          createLine('変更なし行', 'unchanged', 3),
+          createLine('}', 'added', 4),    // 別箇所の閉じ括弧 - 遠隔マッチングされてはいけない
+          createLine('追加されるコードブロック', 'added', 5),
+        ];
+        const result = LinePairingService.pairLinesForSideBySide(lines, false);
+
+        // }のremoved は }のadded と遠隔マッチングされてはいけない
+        const braceRemovedPair = result.find(
+          p => p.original?.line.content === '}' && p.original?.line.type === 'removed'
+        );
+        expect(braceRemovedPair?.modified).toBeNull();
+      });
+
+      it('有意なテキスト行は引き続き遠隔マッチングされる', () => {
+        const lines: DiffLine[] = [
+          createLine('マッチすべき有意なテキスト', 'removed', 1),
+          createLine('変更なし行', 'unchanged', 2),
+          createLine('マッチすべき有意なテキスト', 'added', 3),
+        ];
+        const result = LinePairingService.pairLinesForSideBySide(lines, false);
+
+        // 有意なテキストは遠隔マッチングされるべき
+        const matchedPair = result.find(
+          p => p.original?.line.content === 'マッチすべき有意なテキスト' &&
+               p.modified?.line.content === 'マッチすべき有意なテキスト'
+        );
+        expect(matchedPair).toBeDefined();
+      });
+
+      it('同一ブロック内の空行は位置ベースでペアリングされる', () => {
+        // ブロック内の空行は位置ベースで処理される（遠隔マッチングではない）
+        const lines: DiffLine[] = [
+          createLine('テキスト行1', 'removed', 1),
+          createLine('', 'removed', 2),
+          createLine('テキスト行1', 'added', 3),
+          createLine('', 'added', 4),
+        ];
+        const result = LinePairingService.pairLinesForSideBySide(lines, false);
+
+        // ブロック内の場合: テキスト行はマッチ、空行は位置ベースでペアになる
+        expect(result).toHaveLength(2);
+        const textPair = result.find(p => p.original?.line.content === 'テキスト行1');
+        expect(textPair?.modified?.line.content).toBe('テキスト行1');
+        const emptyPair = result.find(p => p.original?.line.content === '');
+        // 同一ブロック内の空行は位置ベースでペアになる（修正後は fallback で paired）
+        expect(emptyPair).toBeDefined();
+      });
+    });
+
+    // ========================================
+    // G. パフォーマンス考慮
     // ========================================
     describe('パフォーマンス', () => {
       it('大量の行でも処理が完了する', () => {

--- a/src/services/diffService.ts
+++ b/src/services/diffService.ts
@@ -1,5 +1,6 @@
 import type { DiffResult, DiffLine, DiffStats, DiffType, ComparisonOptions } from '../types/types'
 import { TextPreprocessor } from '../utils/textPreprocessor'
+import { CharDiffService } from './charDiffService'
 import { diffLines, type Change } from 'diff'
 
 interface Edit {
@@ -59,11 +60,16 @@ export class DiffService {
     // Select algorithm
     const algorithm = options?.algorithm ?? this.currentAlgorithm;
 
-    if (algorithm === 'jsdiff') {
-      return this.calculateDiffWithJsDiff(processedOriginal, processedModified);
-    } else {
-      return this.calculateDiffWithBuiltin(processedOriginal, processedModified);
+    const result = algorithm === 'jsdiff'
+      ? this.calculateDiffWithJsDiff(processedOriginal, processedModified)
+      : this.calculateDiffWithBuiltin(processedOriginal, processedModified);
+
+    if (options?.enableCharDiff) {
+      const adjustedStats = this.adjustStatsForCharDiff(result.lines, result.stats);
+      return { ...result, stats: adjustedStats };
     }
+
+    return result;
   }
 
   /**
@@ -304,6 +310,56 @@ export class DiffService {
     }
 
     return stats
+  }
+
+  /**
+   * Adjust stats to count char-diff pairs as `modified` instead of separate removed+added.
+   * Scans consecutive change blocks (removed→added or added→removed) and uses positional
+   * pairing to detect which pairs qualify for char-level diff.
+   * Note: uses positional pairing as an approximation; the rendering layer may pair lines
+   * differently via content-similarity matching.
+   */
+  private static adjustStatsForCharDiff(lines: DiffLine[], stats: DiffStats): DiffStats {
+    let modifiedCount = 0;
+    let i = 0;
+
+    while (i < lines.length) {
+      const type = lines[i].type;
+      if (type !== 'removed' && type !== 'added') {
+        i++;
+        continue;
+      }
+
+      // Collect the first run (removed or added)
+      const firstType = type;
+      const secondType = firstType === 'removed' ? 'added' : 'removed';
+
+      const firstStart = i;
+      while (i < lines.length && lines[i].type === firstType) i++;
+      const firstBlock = lines.slice(firstStart, i);
+
+      const secondStart = i;
+      while (i < lines.length && lines[i].type === secondType) i++;
+      const secondBlock = lines.slice(secondStart, i);
+
+      // Normalize to removed/added order for the similarity check
+      const removedBlock = firstType === 'removed' ? firstBlock : secondBlock;
+      const addedBlock = firstType === 'removed' ? secondBlock : firstBlock;
+
+      const minLen = Math.min(removedBlock.length, addedBlock.length);
+      for (let j = 0; j < minLen; j++) {
+        if (CharDiffService.shouldShowCharDiff(removedBlock[j].content, addedBlock[j].content)) {
+          modifiedCount++;
+        }
+      }
+    }
+
+    return {
+      ...stats,
+      removed: stats.removed - modifiedCount,
+      added: stats.added - modifiedCount,
+      modified: modifiedCount,
+    };
   }
 
   /**

--- a/src/services/linePairingService.ts
+++ b/src/services/linePairingService.ts
@@ -43,6 +43,17 @@ export class LinePairingService {
     return this.similarityThreshold;
   }
   /**
+   * Returns true for lines that carry no meaningful context on their own
+   * (blank lines, single structural characters like braces, semicolons).
+   * These should not anchor cross-block remote matching.
+   */
+  private static isContextlessLine(content: string): boolean {
+    const trimmed = content.trim();
+    if (trimmed.length === 0) return true;
+    return /^[{}()\[\];,]+$/.test(trimmed);
+  }
+
+  /**
    * Calculate similarity between two strings (0-1 scale)
    * Uses Levenshtein distance normalized by max length
    */
@@ -85,10 +96,12 @@ export class LinePairingService {
       return [];
     }
 
-    // Calculate similarity matrix
+    // Calculate similarity matrix (skip context-less lines as match anchors)
     const scores: { removedIdx: number; addedIdx: number; score: number }[] = [];
     for (let i = 0; i < removedLines.length; i++) {
+      if (this.isContextlessLine(removedLines[i].content)) continue;
       for (let j = 0; j < addedLines.length; j++) {
+        if (this.isContextlessLine(addedLines[j].content)) continue;
         const score = this.calculateSimilarity(
           removedLines[i].content,
           addedLines[j].content
@@ -148,13 +161,15 @@ export class LinePairingService {
       return [];
     }
 
-    // Find the best matching pair
+    // Find the best matching pair (skip context-less lines as match anchors)
     let bestScore = this.similarityThreshold;
     let bestI = -1;
     let bestJ = -1;
 
     for (let i = 0; i < removedLines.length; i++) {
+      if (this.isContextlessLine(removedLines[i].content)) continue;
       for (let j = 0; j < addedLines.length; j++) {
+        if (this.isContextlessLine(addedLines[j].content)) continue;
         const score = this.calculateSimilarity(
           removedLines[i].content,
           addedLines[j].content
@@ -453,15 +468,17 @@ export class LinePairingService {
     pairs: LinePair[],
     enableCharDiff: boolean
   ): LinePair[] {
-    // Find indices of unmatched lines
+    // Find indices of unmatched lines, excluding context-less lines from remote matching
     const unmatchedRemovedIndices: number[] = [];
     const unmatchedAddedIndices: number[] = [];
 
     pairs.forEach((pair, index) => {
-      if (pair.original && !pair.modified && pair.original.line.type === 'removed') {
+      if (pair.original && !pair.modified && pair.original.line.type === 'removed' &&
+          !this.isContextlessLine(pair.original.line.content)) {
         unmatchedRemovedIndices.push(index);
       }
-      if (pair.modified && !pair.original && pair.modified.line.type === 'added') {
+      if (pair.modified && !pair.original && pair.modified.line.type === 'added' &&
+          !this.isContextlessLine(pair.modified.line.content)) {
         unmatchedAddedIndices.push(index);
       }
     });


### PR DESCRIPTION
## 概要

Issue #97 で報告された2つのバグを修正します。

### Bug 1: 頻出構造行（空行・`}`）の遠隔マッチングで削除ブロックが分断される

`LinePairingService.rematchUnpairedLines` が unmatched な removed/added 行を全体から再マッチングする際、空行や `}` のような「コンテキストレス行」が遠く離れた箇所の同種の行と誤ってマッチングされていました。これにより、本来ひとまとまりの削除ブロック（例: L184〜L239 の 56 行）が分断されて可読性が低下していました。

### Bug 2: `modified` 統計が常に 0

`DiffService.calculateStats` はライン単位の `type` フィールド（`added`/`removed`/`unchanged`）を集計するのみで、差分アルゴリズムが `modified` 型の行を生成しないため、統計上 `~0` と表示され続けていました。char-level diff が有効（`enableCharDiff: true`）なとき、部分変更行を `modified` としてカウントすべきですが実装されていませんでした。

## 変更内容

### `src/services/linePairingService.ts`

- `isContextlessLine(content)` private static メソッドを追加
  - 空行（trim 後に空）または `{}()[];,` のみから成る行を「コンテキストレス」と判定
- `matchByContentGreedy`: コンテキストレス行をスコア計算候補から除外
- `matchByContentRecursive`: コンテキストレス行をベストマッチ探索から除外
- `rematchUnpairedLines`: コンテキストレス行を遠隔マッチング候補から除外

コンテキストレス行はコンテンツ類似度マッチングの対象から外れ、同一ブロック内の位置ベースフォールバックペアリングに委ねられます。

### `src/services/diffService.ts`

- `CharDiffService` をインポート
- `adjustStatsForCharDiff(lines, stats)` private static メソッドを追加
  - 連続する removed→added（または added→removed）ブロックを走査
  - `CharDiffService.shouldShowCharDiff` が true を返すポジショナルペアを `modified` としてカウント
  - `removed` / `added` をその分だけデクリメント
- `calculateDiff`: `enableCharDiff: true` 時に `adjustStatsForCharDiff` を呼び出すよう修正

## テスト

- `src/services/__tests__/linePairingService.test.ts`: セクション F「コンテキストレス行の遠隔マッチング防止」を追加（4ケース）
- `src/__tests__/services/diffService.test.ts`: 新規作成（6ケース）
  - `modified` 統計が `enableCharDiff=false` で 0 のまま
  - 類似行ペアで `modified=1, removed=0, added=0` になること
  - 低類似度行は `modified` にならないこと
  - 合計行数の不変条件（`added + removed + modified*2 + unchanged === lines.length`）

```
Test Files: 5 passed
Tests:      126 passed (116 existing + 10 new)
```

## 関連 Issue

Closes #97
