### PR TITLE
feat: Indent Heuristic の実装（git互換の差分表示改善）

### DIFF
--- a/src/__tests__/services/diffService.test.ts
+++ b/src/__tests__/services/diffService.test.ts
@@ -8,7 +8,6 @@ const defaultOptions: ComparisonOptions = {
   ignoreWhitespace: false,
   ignoreTrailingNewlines: false,
   enableCharDiff: false,
-  indentHeuristic: false,
 };
 
 describe('DiffService', () => {

--- a/src/__tests__/services/diffService.test.ts
+++ b/src/__tests__/services/diffService.test.ts
@@ -8,6 +8,7 @@ const defaultOptions: ComparisonOptions = {
   ignoreWhitespace: false,
   ignoreTrailingNewlines: false,
   enableCharDiff: false,
+  indentHeuristic: false,
 };
 
 describe('DiffService', () => {

--- a/src/__tests__/services/indentHeuristic.test.ts
+++ b/src/__tests__/services/indentHeuristic.test.ts
@@ -23,6 +23,7 @@ const base: DiffCalculationOptions = {
   ignoreWhitespace: false,
   ignoreTrailingNewlines: false,
   enableCharDiff: false,
+  indentHeuristic: false,
 };
 
 // ──────────────────────────────────────────────────────────────────────────────
@@ -198,6 +199,86 @@ describe('indentHeuristic – Category B: indent sliding (builtin)', () => {
     expect(withH.stats.removed).toBe(1);
     const removedLine = withH.lines.find(l => l.type === 'removed');
     expect(removedLine?.originalLineNumber).toBe(2);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Category B (forward slide): white-box test for applySlide forward branch
+//
+// The forward branch of applySlide (toStart > fromStart) handles the case where
+// the optimal split point is to the right of the original Myers position.
+// Forward slides arise when slideRemovedBlocks first slides backward to the
+// leftmost position, then forward scanning finds a lower-indent position
+// further to the right.
+//
+// We exercise that branch directly by invoking the private applySlide method
+// with explicit before/after positions, so the algorithm is verified
+// regardless of which positions the Myers implementation happens to choose.
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('indentHeuristic – Category B: applySlide forward branch (white-box)', () => {
+  type LineLike = {
+    lineNumber: number;
+    content: string;
+    type: 'unchanged' | 'removed' | 'added';
+    originalLineNumber?: number;
+    newLineNumber?: number;
+  };
+
+  // Access private method for white-box testing.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const applySlide = (DiffService as any).applySlide.bind(DiffService) as (
+    lines: LineLike[],
+    fromStart: number,
+    fromEnd: number,
+    toStart: number,
+  ) => void;
+
+  it('forward slide: removed block at [0,1) shifts to [1,2) (size=1)', () => {
+    // Before: removed(X), unchanged(X) → After: unchanged(X), removed(X)
+    const lines: LineLike[] = [
+      { lineNumber: 1, content: 'X', type: 'removed',   originalLineNumber: 1 },
+      { lineNumber: 2, content: 'X', type: 'unchanged', originalLineNumber: 2, newLineNumber: 1 },
+    ];
+
+    applySlide(lines, 0, 1, 1);
+
+    expect(lines[0].type).toBe('unchanged');
+    expect(lines[1].type).toBe('removed');
+    expect(lines[0].content).toBe('X');
+    expect(lines[1].content).toBe('X');
+  });
+
+  it('forward slide: removed block at [0,2) shifts to [2,4) (size=2, shift=2)', () => {
+    // Before: removed(Y), removed(Y), unchanged(Y), unchanged(Y)
+    // After:  unchanged(Y), unchanged(Y), removed(Y), removed(Y)
+    const lines: LineLike[] = [
+      { lineNumber: 1, content: 'Y', type: 'removed',   originalLineNumber: 1 },
+      { lineNumber: 2, content: 'Y', type: 'removed',   originalLineNumber: 2 },
+      { lineNumber: 3, content: 'Y', type: 'unchanged', originalLineNumber: 3, newLineNumber: 1 },
+      { lineNumber: 4, content: 'Y', type: 'unchanged', originalLineNumber: 4, newLineNumber: 2 },
+    ];
+
+    applySlide(lines, 0, 2, 2);
+
+    expect(lines.map(l => l.type)).toEqual(['unchanged', 'unchanged', 'removed', 'removed']);
+  });
+
+  it('forward slide: shift=1 within larger array preserves surrounding lines', () => {
+    // Surrounding unchanged context must remain untouched.
+    const lines: LineLike[] = [
+      { lineNumber: 1, content: 'a', type: 'unchanged', originalLineNumber: 1, newLineNumber: 1 },
+      { lineNumber: 2, content: 'X', type: 'removed',   originalLineNumber: 2 },
+      { lineNumber: 3, content: 'X', type: 'unchanged', originalLineNumber: 3, newLineNumber: 2 },
+      { lineNumber: 4, content: 'b', type: 'unchanged', originalLineNumber: 4, newLineNumber: 3 },
+    ];
+
+    applySlide(lines, 1, 2, 2);
+
+    // [1] removed→unchanged, [2] unchanged→removed; surrounding [0] and [3] unchanged
+    expect(lines.map(l => l.type)).toEqual(['unchanged', 'unchanged', 'removed', 'unchanged']);
+    expect(lines[0].content).toBe('a');
+    expect(lines[3].content).toBe('b');
   });
 });
 

--- a/src/__tests__/services/indentHeuristic.test.ts
+++ b/src/__tests__/services/indentHeuristic.test.ts
@@ -1,304 +1,251 @@
+/**
+ * Tests for the Indent Heuristic feature (Issue #99).
+ *
+ * Two problem categories:
+ *
+ * Category A – jsdiff boundary noise:
+ *   jsdiff sometimes includes context lines inside a removed+added block.
+ *   Those shared prefix lines should be reclassified as unchanged.
+ *
+ * Category B – git-style indent sliding:
+ *   When the same content can be removed at two equal-cost positions, the
+ *   heuristic prefers the position whose surrounding context has the lowest
+ *   indentation (most natural split point). This is the same algorithm as
+ *   git's "indent heuristic" (xdiff/xemit.c).
+ */
 import { describe, it, expect } from 'vitest';
 import { DiffService } from '../../services/diffService';
-import type { ComparisonOptions } from '../../types/types';
+import type { DiffCalculationOptions } from '../../services/diffService';
 
-const baseOptions: ComparisonOptions = {
+const base: DiffCalculationOptions = {
   sortLines: false,
   ignoreCase: false,
   ignoreWhitespace: false,
   ignoreTrailingNewlines: false,
   enableCharDiff: false,
-  indentHeuristic: true,
 };
 
-const noHeuristicOptions: ComparisonOptions = {
-  ...baseOptions,
-  indentHeuristic: false,
-};
+// ──────────────────────────────────────────────────────────────────────────────
+// Category A: jsdiff boundary noise
+// ──────────────────────────────────────────────────────────────────────────────
 
+describe('indentHeuristic – Category A: jsdiff boundary noise', () => {
+  /**
+   * Without heuristic jsdiff produces:
+   *   removed: 'def bar():'
+   *   removed: '    pass'
+   *   added:   'def bar():'
+   *
+   * With heuristic 'def bar():' should be unchanged:
+   *   unchanged: 'def bar():'
+   *   removed:   '    pass'
+   */
+  it('fixes removed+added block with common single-line prefix', () => {
+    const original = 'def foo():\n    pass\ndef bar():\n    pass';
+    const modified  = 'def foo():\n    pass\ndef bar():';
 
-describe('DiffService - indentHeuristic', () => {
-  describe('option disabled', () => {
-    it('with indentHeuristic=false, no sliding occurs', () => {
-      // Original has "    inner" at line 2 and 3; Myers removes line 2 (top-biased)
-      const original = 'def foo():\n    inner\n    inner\ndef bar():';
-      const modified = 'def foo():\n    inner\ndef bar():';
-      const withHeuristic = DiffService.calculateDiff(original, modified, baseOptions);
-      const withoutHeuristic = DiffService.calculateDiff(original, modified, noHeuristicOptions);
-      // They may differ — without heuristic preserves Myers top-biased output
-      expect(withoutHeuristic.lines.some(l => l.type === 'removed')).toBe(true);
-      expect(withHeuristic.lines.some(l => l.type === 'removed')).toBe(true);
+    const without = DiffService.calculateDiff(original, modified, {
+      ...base, algorithm: 'jsdiff', indentHeuristic: false,
     });
+    // Confirm jsdiff has the bug before the fix
+    expect(without.stats.removed).toBe(2);
+    expect(without.stats.added).toBe(1);
+
+    const result = DiffService.calculateDiff(original, modified, {
+      ...base, algorithm: 'jsdiff', indentHeuristic: true,
+    });
+
+    expect(result.stats.removed).toBe(1);
+    expect(result.stats.added).toBe(0);
+    const removedLine = result.lines.find(l => l.type === 'removed');
+    expect(removedLine?.content).toBe('    pass');
+    expect(removedLine?.originalLineNumber).toBe(4);
   });
 
-  describe('no slide when adjacent lines do not match', () => {
-    it('block stays in place when context does not match block content', () => {
-      // "    pass" is removed; adjacent lines are "def foo():" and "def bar():" — no match
-      const original = 'def foo():\n    pass\ndef bar():';
-      const modified = 'def foo():\ndef bar():';
-      const result = DiffService.calculateDiff(original, modified, baseOptions);
-      const removed = result.lines.find(l => l.type === 'removed');
-      expect(removed).toBeDefined();
-      expect(removed!.content).toBe('    pass');
-      // Removed line should still be between unchanged "def foo():" and "def bar():"
-      const removedIdx = result.lines.indexOf(removed!);
-      expect(result.lines[removedIdx - 1].content).toBe('def foo():');
-      expect(result.lines[removedIdx + 1].content).toBe('def bar():');
+  it('fixes removed+added block with blank-line separator in original', () => {
+    const original = 'def foo():\n    bar()\n\ndef baz():\n    bar()';
+    const modified  = 'def foo():\n    bar()\n\ndef baz():';
+
+    const without = DiffService.calculateDiff(original, modified, {
+      ...base, algorithm: 'jsdiff', indentHeuristic: false,
     });
+    expect(without.stats.removed).toBe(2);
+    expect(without.stats.added).toBe(1);
+
+    const result = DiffService.calculateDiff(original, modified, {
+      ...base, algorithm: 'jsdiff', indentHeuristic: true,
+    });
+
+    expect(result.stats.removed).toBe(1);
+    expect(result.stats.added).toBe(0);
+    const removedLine = result.lines.find(l => l.type === 'removed');
+    expect(removedLine?.content).toBe('    bar()');
   });
 
-  describe('slide up when prior context has lower indent', () => {
-    it('removed block slides up past matching unchanged line to reach lower-indent boundary', () => {
-      // Original:
-      //   def foo():    ← indent 0
-      //       inner     ← indent 4 (unchanged)
-      //       inner     ← indent 4 (will be removed — Myers top-biased removes line 2)
-      //   def bar():
-      //
-      // Myers without heuristic removes the FIRST "    inner" (line 2):
-      //   unchanged: def foo():
-      //   removed:       inner   ← before "    inner" (indent=4), score=4
-      //   unchanged:     inner
-      //   unchanged: def bar():
-      //
-      // Heuristic: can slide up? No — removed block is already at top of duplicates.
-      // Heuristic: can slide down? lines[blockEnd]="    inner" matches "    inner" → yes
-      //   After slide: block at index 2, score=indent("    inner")=4 — same as current
-      //   No improvement, stays.
-      //
-      // Let's flip: make removed block be currently AFTER a high-indent line and
-      // able to slide to a lower-indent position.
-      //
-      // Original:
-      //   def foo():     ← indent 0 (line 1)
-      //       inner      ← indent 4 (line 2)
-      //       inner      ← indent 4 (line 3)  ← Myers removes this (bottom is line 3)
-      //   def bar():
-      //
-      // Wait — Myers is top-biased, so it removes line 2, not line 3.
-      // To get a removed block that's already at position 2 (0-indexed), we need a
-      // different arrangement. Let's construct it directly.
-      //
-      // Arrange: removed block is at index 2 (after two unchanged lines),
-      // and there's a matching unchanged line at index 1 → can slide up to index 1.
-      // Line before index 2: "    inner" (indent 4)
-      // Line before index 1: "def foo():" (indent 0)  ← better
-      //
-      // To get Myers to produce this arrangement, we need a case where the removed
-      // line appears AFTER an equally-indented unchanged line.
-      //
-      // Concrete case:
-      //   Original: line1="def foo():", line2="    inner", line3="    inner", line4="def bar():"
-      //   Modified: line1="def foo():", line2="    inner", line3="def bar():"
-      //   Myers removes one "    inner"; top-biased removes line2 (index 1 in 0-based).
-      //   Block at index 1, blockEnd=2.
-      //   Slide down: lines[2]="    inner" matches block line[0]="    inner" → can slide!
-      //   Position 1: prior="def foo():" indent=0, score=0
-      //   Position 2: prior="    inner" indent=4, score=4
-      //   Position 1 is better → NO slide (stays at 1).
-      //
-      // So actually for this test case the heuristic should NOT slide.
-      // Let's verify that property:
-      const original = 'def foo():\n    inner\n    inner\ndef bar():';
-      const modified = 'def foo():\n    inner\ndef bar():';
-      const result = DiffService.calculateDiff(original, modified, baseOptions);
-      const removed = result.lines.find(l => l.type === 'removed');
-      expect(removed).toBeDefined();
-      expect(removed!.content).toBe('    inner');
-      // Should be at index 1 (after def foo():), NOT slid to index 2
-      const removedIdx = result.lines.indexOf(removed!);
-      expect(result.lines[removedIdx - 1].content).toBe('def foo():');
-      expect(result.lines[removedIdx - 1].type).toBe('unchanged');
+  it('does not change already-optimal jsdiff output (no common prefix)', () => {
+    const original = 'def foo():\n    pass\ndef bar():\n    pass';
+    const modified  = 'def foo():\n    pass\ndef bar():\n    body';
+
+    const result = DiffService.calculateDiff(original, modified, {
+      ...base, algorithm: 'jsdiff', indentHeuristic: true,
     });
 
-    it('removed block stays at optimal position (no slide when already at lowest indent context)', () => {
-      // Original:  def foo(): /     pass / def bar():
-      // Modified:  def foo(): / def bar():
-      // jsdiff removes "    pass". Prior line is "def foo():" (indent=0) — already optimal.
-      // Adjacent lines: "def foo():" and "def bar():" don't match "    pass" → no slide.
-      const original = 'def foo():\n    pass\ndef bar():';
-      const modified = 'def foo():\ndef bar():';
-      const result = DiffService.calculateDiff(original, modified, baseOptions);
-      const removed = result.lines.find(l => l.type === 'removed');
-      expect(removed).toBeDefined();
-      expect(removed!.content).toBe('    pass');
-      const removedIdx = result.lines.indexOf(removed!);
-      expect(result.lines[removedIdx - 1].content).toBe('def foo():');
-      expect(result.lines[removedIdx - 1].type).toBe('unchanged');
+    expect(result.stats.removed).toBe(1);
+    expect(result.stats.added).toBe(1);
+    const removedLine = result.lines.find(l => l.type === 'removed');
+    expect(removedLine?.content).toBe('    pass');
+    const addedLine = result.lines.find(l => l.type === 'added');
+    expect(addedLine?.content).toBe('    body');
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Category B: git-style indent sliding (builtin algorithm)
+//
+// The classic case: two consecutive identical lines in original, one removed.
+// Myers places the removal at the LATER position (higher indent context).
+// The heuristic slides it BACKWARD to the position with the lowest pre-indent.
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('indentHeuristic – Category B: indent sliding (builtin)', () => {
+  /**
+   * Original:
+   *   A() {
+   *       doStuff();   ← orig line 2
+   *       doStuff();   ← orig line 3  (Myers removes this one)
+   *       doEnd();
+   *   }
+   *
+   * Modified:
+   *   A() {
+   *       doStuff();
+   *       doEnd();
+   *   }
+   *
+   * Myers scores:
+   *   Position at orig line 3: pre='    doStuff();'(4) + post='    doEnd();'(4) = 8
+   *   Position at orig line 2: pre='A() {'(0)          + post='    doStuff();'(4) = 4
+   *
+   * Heuristic should slide backward to orig line 2 (lower score).
+   */
+  it('slides removal backward when pre-context has lower indentation', () => {
+    const original = 'A() {\n    doStuff();\n    doStuff();\n    doEnd();\n}';
+    const modified  = 'A() {\n    doStuff();\n    doEnd();\n}';
+
+    const withoutH = DiffService.calculateDiff(original, modified, {
+      ...base, algorithm: 'builtin', indentHeuristic: false,
     });
+    // Myers places removal at orig line 3 (second doStuff)
+    const removedWithout = withoutH.lines.find(l => l.type === 'removed');
+    expect(removedWithout?.originalLineNumber).toBe(3);
+
+    const withH = DiffService.calculateDiff(original, modified, {
+      ...base, algorithm: 'builtin', indentHeuristic: true,
+    });
+
+    expect(withH.stats.removed).toBe(1);
+    // Heuristic should move removal to orig line 2 (first doStuff, lower pre-context indent)
+    const removedWith = withH.lines.find(l => l.type === 'removed');
+    expect(removedWith?.originalLineNumber).toBe(2);
   });
 
-  describe('slide down when current position has higher indent', () => {
-    it('removed block slides down when next unchanged line matches and has lower prior indent', () => {
-      // Construct: a removed block currently at a high-indent position,
-      // and sliding down puts it after a lower-indent line.
-      //
-      // Original lines: "    a", "    a", "b"
-      // Modified lines: "    a", "b"
-      // Myers removes line 1 ("    a"):
-      //   removed: "    a"    (index 0, no prior → score=0)
-      //   unchanged: "    a"  (same content → can slide down)
-      //   unchanged: "b"
-      //
-      // Slide down: lines[1]="    a" matches lines[0]="    a" ✓
-      //   Position 1: prior="    a" (indent=4), score=4 — WORSE than current (0)
-      //   → No slide (current position wins)
-      //
-      // This confirms: if current position has score=0 (no prior), it always wins.
-      // Now let's test a case where the current removed block is NOT at the top:
-      //
-      // Original: "b", "    a", "    a"
-      // Modified: "b", "    a"
-      // Myers removes line 2 ("    a"):
-      //   unchanged: "b"       (index 0)
-      //   removed: "    a"     (index 1, prior="b" indent=0, score=0)
-      //   unchanged: "    a"   (index 2, same content → can slide down)
-      //
-      // Slide down: lines[2]="    a" matches lines[1]="    a" ✓
-      //   Position 2: prior="    a" (indent=4), score=4 — worse
-      //   → No slide (current wins)
-      //
-      // Sliding down is only useful when it moves to a LOWER-indent position.
-      // Let's check: if we have "    a" removed at index 1, after "b" (indent=0),
-      // and sliding down puts it after "b" again... still score 0. No preference.
+  it('preserves sequential line numbers after backward sliding', () => {
+    const original = 'A() {\n    doStuff();\n    doStuff();\n    doEnd();\n}';
+    const modified  = 'A() {\n    doStuff();\n    doEnd();\n}';
 
-      const original = 'b\n    a\n    a';
-      const modified = 'b\n    a';
-      const result = DiffService.calculateDiff(original, modified, baseOptions);
-      expect(result.stats.removed).toBe(1);
-      expect(result.stats.added).toBe(0);
-      // Block should stay after "b" (the best position)
-      const removed = result.lines.find(l => l.type === 'removed');
-      expect(removed!.content).toBe('    a');
+    const result = DiffService.calculateDiff(original, modified, {
+      ...base, algorithm: 'builtin', indentHeuristic: true,
     });
+
+    const origNums = result.lines
+      .filter(l => l.originalLineNumber !== undefined)
+      .map(l => l.originalLineNumber as number)
+      .sort((a, b) => a - b);
+    const newNums = result.lines
+      .filter(l => l.newLineNumber !== undefined)
+      .map(l => l.newLineNumber as number)
+      .sort((a, b) => a - b);
+
+    expect(origNums).toEqual([1, 2, 3, 4, 5]);
+    expect(newNums).toEqual([1, 2, 3, 4]);
   });
 
-  describe('slide produces correct line numbers', () => {
-    it('line numbers are consistent after heuristic is applied', () => {
-      const original = 'def foo():\n    inner\n    inner\ndef bar():';
-      const modified = 'def foo():\n    inner\ndef bar():';
-      const result = DiffService.calculateDiff(original, modified, baseOptions);
+  it('does not slide when all candidate positions have equal score', () => {
+    // Two top-level functions each with same body; one removed from function a
+    // All context lines have indent 0 → equal scores → no slide
+    const original = 'foo() {\n    body();\n}\nbar() {\n    body();\n}';
+    const modified  = 'foo() {\n}\nbar() {\n    body();\n}';
 
-      let origNum = 1;
-      let newNum = 1;
-      for (const line of result.lines) {
-        if (line.type === 'removed') {
-          expect(line.originalLineNumber).toBe(origNum++);
-          expect(line.newLineNumber).toBeUndefined();
-        } else if (line.type === 'added') {
-          expect(line.originalLineNumber).toBeUndefined();
-          expect(line.newLineNumber).toBe(newNum++);
-        } else {
-          expect(line.originalLineNumber).toBe(origNum++);
-          expect(line.newLineNumber).toBe(newNum++);
-        }
-      }
+    const result = DiffService.calculateDiff(original, modified, {
+      ...base, algorithm: 'builtin', indentHeuristic: true,
     });
+
+    expect(result.stats.removed).toBe(1);
+    expect(result.stats.added).toBe(0);
+    const removedLine = result.lines.find(l => l.type === 'removed');
+    expect(removedLine?.content).toBe('    body();');
   });
 
-  describe('statistics unchanged by heuristic', () => {
-    it('added/removed counts are the same with and without heuristic', () => {
-      const original = 'def foo():\n    inner\n    inner\ndef bar():';
-      const modified = 'def foo():\n    inner\ndef bar():';
-      const with_ = DiffService.calculateDiff(original, modified, baseOptions);
-      const without = DiffService.calculateDiff(original, modified, noHeuristicOptions);
-      expect(with_.stats.added).toBe(without.stats.added);
-      expect(with_.stats.removed).toBe(without.stats.removed);
-      expect(with_.stats.unchanged).toBe(without.stats.unchanged);
+  it('slides tab-indented removal to lower pre-context position', () => {
+    // Same pattern as doStuff but with tab indentation
+    const original = 'A() {\n\tdoStuff();\n\tdoStuff();\n\tdoEnd();\n}';
+    const modified  = 'A() {\n\tdoStuff();\n\tdoEnd();\n}';
+
+    const withH = DiffService.calculateDiff(original, modified, {
+      ...base, algorithm: 'builtin', indentHeuristic: true,
     });
+
+    expect(withH.stats.removed).toBe(1);
+    const removedLine = withH.lines.find(l => l.type === 'removed');
+    expect(removedLine?.originalLineNumber).toBe(2);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// General correctness (both algorithms)
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('indentHeuristic – general correctness', () => {
+  it.each(['builtin', 'jsdiff'] as const)('(%s) unchanged count is preserved after heuristic', (algo) => {
+    const original = 'A() {\n    doStuff();\n    doStuff();\n    doEnd();\n}';
+    const modified  = 'A() {\n    doStuff();\n    doEnd();\n}';
+
+    const result = DiffService.calculateDiff(original, modified, {
+      ...base, algorithm: algo, indentHeuristic: true,
+    });
+    expect(result.stats.unchanged).toBe(4);
   });
 
-  describe('added block heuristic', () => {
-    it('added block with no adjacent match stays in place', () => {
-      const original = 'def foo():\ndef bar():';
-      const modified = 'def foo():\n    pass\ndef bar():';
-      const result = DiffService.calculateDiff(original, modified, baseOptions);
-      const added = result.lines.find(l => l.type === 'added');
-      expect(added).toBeDefined();
-      expect(added!.content).toBe('    pass');
-      const addedIdx = result.lines.indexOf(added!);
-      expect(result.lines[addedIdx - 1].content).toBe('def foo():');
-      expect(result.lines[addedIdx + 1].content).toBe('def bar():');
+  it.each(['builtin', 'jsdiff'] as const)('(%s) handles empty input gracefully', (algo) => {
+    const result = DiffService.calculateDiff('', '', {
+      ...base, algorithm: algo, indentHeuristic: true,
     });
-
-    it('added block slides down when it finds a lower-indent boundary below', () => {
-      // Original: "def foo():", "def bar():"
-      // Modified: "def foo():", "    pass", "def bar():", "    pass"
-      // Myers: adds "    pass" twice — but placed at the top (after def foo())
-      // This tests that added blocks are processed similarly to removed blocks.
-      const original = 'foo\n    a\n    a\nbar';
-      const modified = 'foo\n    a\nbar';
-      const result = DiffService.calculateDiff(original, modified, baseOptions);
-      expect(result.stats.removed).toBe(1);
-      expect(result.stats.added).toBe(0);
-    });
+    expect(result.stats.added).toBe(0);
+    expect(result.stats.removed).toBe(0);
   });
 
-  describe('multi-line removed block', () => {
-    it('multi-line block stays when context does not match', () => {
-      const original = 'a\nb\nc\nd';
-      const modified = 'a\nd';
-      const result = DiffService.calculateDiff(original, modified, baseOptions);
-      expect(result.stats.removed).toBe(2);
-      const removedLines = result.lines.filter(l => l.type === 'removed');
-      expect(removedLines.map(l => l.content)).toEqual(['b', 'c']);
-    });
+  it.each(['builtin', 'jsdiff'] as const)('(%s) indentHeuristic=false preserves standard output', (algo) => {
+    const original = 'def foo():\n    pass\ndef bar():\n    pass';
+    const modified  = 'def foo():\n    pass\ndef bar():\n    body';
 
-    it('multi-line block slides up to lower-indent position', () => {
-      // Original:
-      //   line1: "    a"   ← indent 4
-      //   line2: "    b"   ← indent 4
-      //   line3: "    a"   ← indent 4 (same as line1)
-      //   line4: "    b"   ← indent 4 (same as line2)
-      //   line5: "c"       ← indent 0
-      //
-      // Modified:
-      //   line1: "    a"
-      //   line2: "    b"
-      //   line3: "c"
-      //
-      // Myers removes lines 3-4 ("    a","    b"):
-      //   unchanged: "    a"    index 0
-      //   unchanged: "    b"    index 1
-      //   removed: "    a"      index 2 (prior="    b" indent=4, score=4)
-      //   removed: "    b"      index 3
-      //   unchanged: "c"        index 4
-      //
-      // Slide up: lines[1]="    b" matches last of block lines[3]="    b" ✓
-      //   → slide to position 1:
-      //   lines[0]="    a" matches last of new block lines[2]="    a"? We need to check
-      //   if the full slide-up chain works.
-      //
-      // After 1 slide up (block [2,4) → [1,3)):
-      //   unchanged: "    a"   index 0
-      //   removed: "    a"     index 1 (prior="    a" indent=4, score=4)
-      //   removed: "    b"     index 2
-      //   unchanged: "    b"   index 3
-      //   unchanged: "c"       index 4
-      //
-      // After 2 slides up (block [1,3) → [0,2)):
-      //   removed: "    a"     index 0 (prior=none, score=0)
-      //   removed: "    b"     index 1
-      //   unchanged: "    a"   index 2
-      //   unchanged: "    b"   index 3
-      //   unchanged: "c"       index 4
-      //
-      // Score at [0,2): 0 < 4 → SLIDE UP to position 0!
-      //
-      const original = '    a\n    b\n    a\n    b\nc';
-      const modified = '    a\n    b\nc';
-      const result = DiffService.calculateDiff(original, modified, baseOptions);
-      expect(result.stats.removed).toBe(2);
-      const removedLines = result.lines.filter(l => l.type === 'removed');
-      // With heuristic: block slid to index 0 (no prior, score=0)
-      expect(removedLines[0].content).toBe('    a');
-      expect(removedLines[1].content).toBe('    b');
-      // They should be at the BEGINNING (indices 0,1)
-      expect(result.lines[0].type).toBe('removed');
-      expect(result.lines[1].type).toBe('removed');
-      expect(result.lines[2].type).toBe('unchanged');
-      expect(result.lines[3].type).toBe('unchanged');
-      expect(result.lines[4].type).toBe('unchanged');
+    const result = DiffService.calculateDiff(original, modified, {
+      ...base, algorithm: algo, indentHeuristic: false,
     });
+    expect(result.stats.removed).toBe(1);
+    expect(result.stats.added).toBe(1);
+  });
+
+  it('stats sum equals total diff lines after heuristic', () => {
+    const original = 'A() {\n    doStuff();\n    doStuff();\n    doEnd();\n}';
+    const modified  = 'A() {\n    doStuff();\n    doEnd();\n}';
+
+    const result = DiffService.calculateDiff(original, modified, {
+      ...base, algorithm: 'builtin', indentHeuristic: true,
+    });
+    // removed lines are in original only, added in modified only, modified×2, unchanged in both
+    const total = result.stats.added + result.stats.removed + result.stats.unchanged;
+    // For pure removed-only diff: added=0, so total = removed + unchanged = line count of original
+    expect(total).toBeGreaterThan(0);
+    expect(result.stats.removed).toBe(1);
   });
 });

--- a/src/__tests__/services/indentHeuristic.test.ts
+++ b/src/__tests__/services/indentHeuristic.test.ts
@@ -1,0 +1,304 @@
+import { describe, it, expect } from 'vitest';
+import { DiffService } from '../../services/diffService';
+import type { ComparisonOptions } from '../../types/types';
+
+const baseOptions: ComparisonOptions = {
+  sortLines: false,
+  ignoreCase: false,
+  ignoreWhitespace: false,
+  ignoreTrailingNewlines: false,
+  enableCharDiff: false,
+  indentHeuristic: true,
+};
+
+const noHeuristicOptions: ComparisonOptions = {
+  ...baseOptions,
+  indentHeuristic: false,
+};
+
+
+describe('DiffService - indentHeuristic', () => {
+  describe('option disabled', () => {
+    it('with indentHeuristic=false, no sliding occurs', () => {
+      // Original has "    inner" at line 2 and 3; Myers removes line 2 (top-biased)
+      const original = 'def foo():\n    inner\n    inner\ndef bar():';
+      const modified = 'def foo():\n    inner\ndef bar():';
+      const withHeuristic = DiffService.calculateDiff(original, modified, baseOptions);
+      const withoutHeuristic = DiffService.calculateDiff(original, modified, noHeuristicOptions);
+      // They may differ — without heuristic preserves Myers top-biased output
+      expect(withoutHeuristic.lines.some(l => l.type === 'removed')).toBe(true);
+      expect(withHeuristic.lines.some(l => l.type === 'removed')).toBe(true);
+    });
+  });
+
+  describe('no slide when adjacent lines do not match', () => {
+    it('block stays in place when context does not match block content', () => {
+      // "    pass" is removed; adjacent lines are "def foo():" and "def bar():" — no match
+      const original = 'def foo():\n    pass\ndef bar():';
+      const modified = 'def foo():\ndef bar():';
+      const result = DiffService.calculateDiff(original, modified, baseOptions);
+      const removed = result.lines.find(l => l.type === 'removed');
+      expect(removed).toBeDefined();
+      expect(removed!.content).toBe('    pass');
+      // Removed line should still be between unchanged "def foo():" and "def bar():"
+      const removedIdx = result.lines.indexOf(removed!);
+      expect(result.lines[removedIdx - 1].content).toBe('def foo():');
+      expect(result.lines[removedIdx + 1].content).toBe('def bar():');
+    });
+  });
+
+  describe('slide up when prior context has lower indent', () => {
+    it('removed block slides up past matching unchanged line to reach lower-indent boundary', () => {
+      // Original:
+      //   def foo():    ← indent 0
+      //       inner     ← indent 4 (unchanged)
+      //       inner     ← indent 4 (will be removed — Myers top-biased removes line 2)
+      //   def bar():
+      //
+      // Myers without heuristic removes the FIRST "    inner" (line 2):
+      //   unchanged: def foo():
+      //   removed:       inner   ← before "    inner" (indent=4), score=4
+      //   unchanged:     inner
+      //   unchanged: def bar():
+      //
+      // Heuristic: can slide up? No — removed block is already at top of duplicates.
+      // Heuristic: can slide down? lines[blockEnd]="    inner" matches "    inner" → yes
+      //   After slide: block at index 2, score=indent("    inner")=4 — same as current
+      //   No improvement, stays.
+      //
+      // Let's flip: make removed block be currently AFTER a high-indent line and
+      // able to slide to a lower-indent position.
+      //
+      // Original:
+      //   def foo():     ← indent 0 (line 1)
+      //       inner      ← indent 4 (line 2)
+      //       inner      ← indent 4 (line 3)  ← Myers removes this (bottom is line 3)
+      //   def bar():
+      //
+      // Wait — Myers is top-biased, so it removes line 2, not line 3.
+      // To get a removed block that's already at position 2 (0-indexed), we need a
+      // different arrangement. Let's construct it directly.
+      //
+      // Arrange: removed block is at index 2 (after two unchanged lines),
+      // and there's a matching unchanged line at index 1 → can slide up to index 1.
+      // Line before index 2: "    inner" (indent 4)
+      // Line before index 1: "def foo():" (indent 0)  ← better
+      //
+      // To get Myers to produce this arrangement, we need a case where the removed
+      // line appears AFTER an equally-indented unchanged line.
+      //
+      // Concrete case:
+      //   Original: line1="def foo():", line2="    inner", line3="    inner", line4="def bar():"
+      //   Modified: line1="def foo():", line2="    inner", line3="def bar():"
+      //   Myers removes one "    inner"; top-biased removes line2 (index 1 in 0-based).
+      //   Block at index 1, blockEnd=2.
+      //   Slide down: lines[2]="    inner" matches block line[0]="    inner" → can slide!
+      //   Position 1: prior="def foo():" indent=0, score=0
+      //   Position 2: prior="    inner" indent=4, score=4
+      //   Position 1 is better → NO slide (stays at 1).
+      //
+      // So actually for this test case the heuristic should NOT slide.
+      // Let's verify that property:
+      const original = 'def foo():\n    inner\n    inner\ndef bar():';
+      const modified = 'def foo():\n    inner\ndef bar():';
+      const result = DiffService.calculateDiff(original, modified, baseOptions);
+      const removed = result.lines.find(l => l.type === 'removed');
+      expect(removed).toBeDefined();
+      expect(removed!.content).toBe('    inner');
+      // Should be at index 1 (after def foo():), NOT slid to index 2
+      const removedIdx = result.lines.indexOf(removed!);
+      expect(result.lines[removedIdx - 1].content).toBe('def foo():');
+      expect(result.lines[removedIdx - 1].type).toBe('unchanged');
+    });
+
+    it('removed block stays at optimal position (no slide when already at lowest indent context)', () => {
+      // Original:  def foo(): /     pass / def bar():
+      // Modified:  def foo(): / def bar():
+      // jsdiff removes "    pass". Prior line is "def foo():" (indent=0) — already optimal.
+      // Adjacent lines: "def foo():" and "def bar():" don't match "    pass" → no slide.
+      const original = 'def foo():\n    pass\ndef bar():';
+      const modified = 'def foo():\ndef bar():';
+      const result = DiffService.calculateDiff(original, modified, baseOptions);
+      const removed = result.lines.find(l => l.type === 'removed');
+      expect(removed).toBeDefined();
+      expect(removed!.content).toBe('    pass');
+      const removedIdx = result.lines.indexOf(removed!);
+      expect(result.lines[removedIdx - 1].content).toBe('def foo():');
+      expect(result.lines[removedIdx - 1].type).toBe('unchanged');
+    });
+  });
+
+  describe('slide down when current position has higher indent', () => {
+    it('removed block slides down when next unchanged line matches and has lower prior indent', () => {
+      // Construct: a removed block currently at a high-indent position,
+      // and sliding down puts it after a lower-indent line.
+      //
+      // Original lines: "    a", "    a", "b"
+      // Modified lines: "    a", "b"
+      // Myers removes line 1 ("    a"):
+      //   removed: "    a"    (index 0, no prior → score=0)
+      //   unchanged: "    a"  (same content → can slide down)
+      //   unchanged: "b"
+      //
+      // Slide down: lines[1]="    a" matches lines[0]="    a" ✓
+      //   Position 1: prior="    a" (indent=4), score=4 — WORSE than current (0)
+      //   → No slide (current position wins)
+      //
+      // This confirms: if current position has score=0 (no prior), it always wins.
+      // Now let's test a case where the current removed block is NOT at the top:
+      //
+      // Original: "b", "    a", "    a"
+      // Modified: "b", "    a"
+      // Myers removes line 2 ("    a"):
+      //   unchanged: "b"       (index 0)
+      //   removed: "    a"     (index 1, prior="b" indent=0, score=0)
+      //   unchanged: "    a"   (index 2, same content → can slide down)
+      //
+      // Slide down: lines[2]="    a" matches lines[1]="    a" ✓
+      //   Position 2: prior="    a" (indent=4), score=4 — worse
+      //   → No slide (current wins)
+      //
+      // Sliding down is only useful when it moves to a LOWER-indent position.
+      // Let's check: if we have "    a" removed at index 1, after "b" (indent=0),
+      // and sliding down puts it after "b" again... still score 0. No preference.
+
+      const original = 'b\n    a\n    a';
+      const modified = 'b\n    a';
+      const result = DiffService.calculateDiff(original, modified, baseOptions);
+      expect(result.stats.removed).toBe(1);
+      expect(result.stats.added).toBe(0);
+      // Block should stay after "b" (the best position)
+      const removed = result.lines.find(l => l.type === 'removed');
+      expect(removed!.content).toBe('    a');
+    });
+  });
+
+  describe('slide produces correct line numbers', () => {
+    it('line numbers are consistent after heuristic is applied', () => {
+      const original = 'def foo():\n    inner\n    inner\ndef bar():';
+      const modified = 'def foo():\n    inner\ndef bar():';
+      const result = DiffService.calculateDiff(original, modified, baseOptions);
+
+      let origNum = 1;
+      let newNum = 1;
+      for (const line of result.lines) {
+        if (line.type === 'removed') {
+          expect(line.originalLineNumber).toBe(origNum++);
+          expect(line.newLineNumber).toBeUndefined();
+        } else if (line.type === 'added') {
+          expect(line.originalLineNumber).toBeUndefined();
+          expect(line.newLineNumber).toBe(newNum++);
+        } else {
+          expect(line.originalLineNumber).toBe(origNum++);
+          expect(line.newLineNumber).toBe(newNum++);
+        }
+      }
+    });
+  });
+
+  describe('statistics unchanged by heuristic', () => {
+    it('added/removed counts are the same with and without heuristic', () => {
+      const original = 'def foo():\n    inner\n    inner\ndef bar():';
+      const modified = 'def foo():\n    inner\ndef bar():';
+      const with_ = DiffService.calculateDiff(original, modified, baseOptions);
+      const without = DiffService.calculateDiff(original, modified, noHeuristicOptions);
+      expect(with_.stats.added).toBe(without.stats.added);
+      expect(with_.stats.removed).toBe(without.stats.removed);
+      expect(with_.stats.unchanged).toBe(without.stats.unchanged);
+    });
+  });
+
+  describe('added block heuristic', () => {
+    it('added block with no adjacent match stays in place', () => {
+      const original = 'def foo():\ndef bar():';
+      const modified = 'def foo():\n    pass\ndef bar():';
+      const result = DiffService.calculateDiff(original, modified, baseOptions);
+      const added = result.lines.find(l => l.type === 'added');
+      expect(added).toBeDefined();
+      expect(added!.content).toBe('    pass');
+      const addedIdx = result.lines.indexOf(added!);
+      expect(result.lines[addedIdx - 1].content).toBe('def foo():');
+      expect(result.lines[addedIdx + 1].content).toBe('def bar():');
+    });
+
+    it('added block slides down when it finds a lower-indent boundary below', () => {
+      // Original: "def foo():", "def bar():"
+      // Modified: "def foo():", "    pass", "def bar():", "    pass"
+      // Myers: adds "    pass" twice — but placed at the top (after def foo())
+      // This tests that added blocks are processed similarly to removed blocks.
+      const original = 'foo\n    a\n    a\nbar';
+      const modified = 'foo\n    a\nbar';
+      const result = DiffService.calculateDiff(original, modified, baseOptions);
+      expect(result.stats.removed).toBe(1);
+      expect(result.stats.added).toBe(0);
+    });
+  });
+
+  describe('multi-line removed block', () => {
+    it('multi-line block stays when context does not match', () => {
+      const original = 'a\nb\nc\nd';
+      const modified = 'a\nd';
+      const result = DiffService.calculateDiff(original, modified, baseOptions);
+      expect(result.stats.removed).toBe(2);
+      const removedLines = result.lines.filter(l => l.type === 'removed');
+      expect(removedLines.map(l => l.content)).toEqual(['b', 'c']);
+    });
+
+    it('multi-line block slides up to lower-indent position', () => {
+      // Original:
+      //   line1: "    a"   ← indent 4
+      //   line2: "    b"   ← indent 4
+      //   line3: "    a"   ← indent 4 (same as line1)
+      //   line4: "    b"   ← indent 4 (same as line2)
+      //   line5: "c"       ← indent 0
+      //
+      // Modified:
+      //   line1: "    a"
+      //   line2: "    b"
+      //   line3: "c"
+      //
+      // Myers removes lines 3-4 ("    a","    b"):
+      //   unchanged: "    a"    index 0
+      //   unchanged: "    b"    index 1
+      //   removed: "    a"      index 2 (prior="    b" indent=4, score=4)
+      //   removed: "    b"      index 3
+      //   unchanged: "c"        index 4
+      //
+      // Slide up: lines[1]="    b" matches last of block lines[3]="    b" ✓
+      //   → slide to position 1:
+      //   lines[0]="    a" matches last of new block lines[2]="    a"? We need to check
+      //   if the full slide-up chain works.
+      //
+      // After 1 slide up (block [2,4) → [1,3)):
+      //   unchanged: "    a"   index 0
+      //   removed: "    a"     index 1 (prior="    a" indent=4, score=4)
+      //   removed: "    b"     index 2
+      //   unchanged: "    b"   index 3
+      //   unchanged: "c"       index 4
+      //
+      // After 2 slides up (block [1,3) → [0,2)):
+      //   removed: "    a"     index 0 (prior=none, score=0)
+      //   removed: "    b"     index 1
+      //   unchanged: "    a"   index 2
+      //   unchanged: "    b"   index 3
+      //   unchanged: "c"       index 4
+      //
+      // Score at [0,2): 0 < 4 → SLIDE UP to position 0!
+      //
+      const original = '    a\n    b\n    a\n    b\nc';
+      const modified = '    a\n    b\nc';
+      const result = DiffService.calculateDiff(original, modified, baseOptions);
+      expect(result.stats.removed).toBe(2);
+      const removedLines = result.lines.filter(l => l.type === 'removed');
+      // With heuristic: block slid to index 0 (no prior, score=0)
+      expect(removedLines[0].content).toBe('    a');
+      expect(removedLines[1].content).toBe('    b');
+      // They should be at the BEGINNING (indices 0,1)
+      expect(result.lines[0].type).toBe('removed');
+      expect(result.lines[1].type).toBe('removed');
+      expect(result.lines[2].type).toBe('unchanged');
+      expect(result.lines[3].type).toBe('unchanged');
+      expect(result.lines[4].type).toBe('unchanged');
+    });
+  });
+});

--- a/src/components/diff/ComparisonOptionsHorizontal.tsx
+++ b/src/components/diff/ComparisonOptionsHorizontal.tsx
@@ -56,6 +56,11 @@ export const ComparisonOptionsHorizontal: React.FC<ComparisonOptionsHorizontalPr
       key: 'enableCharDiff' as const,
       label: t('comparisonOptions.enableCharDiffLabel'),
       description: t('comparisonOptions.enableCharDiffTooltip')
+    },
+    {
+      key: 'indentHeuristic' as const,
+      label: t('comparisonOptions.indentHeuristicLabel'),
+      description: t('comparisonOptions.indentHeuristicTooltip')
     }
   ];
 

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -47,6 +47,9 @@
     "enableCharDiff": "Zeichenhervorhebung",
     "enableCharDiffLabel": "Zeichenhervorhebung",
     "enableCharDiffTooltip": "Geänderte Zeichen in Zeilen hervorheben",
+    "indentHeuristic": "Einrückungs-Heuristik",
+    "indentHeuristicLabel": "Einrückungs-Heuristik",
+    "indentHeuristicTooltip": "Git-kompatible Diff-Anzeige (Diff-Blöcke an weniger eingerückte Positionen verschieben)",
     "collapseUnchanged": "Unveränderte Zeilen ausblenden",
     "collapseUnchangedLabel": "Unveränderte Zeilen ausblenden",
     "collapseUnchangedTooltip": "Nur Kontext um Änderungen anzeigen (GitHub-Stil)"

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -47,6 +47,9 @@
     "enableCharDiff": "Character highlighting",
     "enableCharDiffLabel": "Character highlighting",
     "enableCharDiffTooltip": "Highlight changed characters within lines",
+    "indentHeuristic": "Indent heuristic",
+    "indentHeuristicLabel": "Indent heuristic",
+    "indentHeuristicTooltip": "Git-compatible diff display (slide diff blocks to lower-indent positions)",
     "collapseUnchanged": "Collapse unchanged",
     "collapseUnchangedLabel": "Collapse unchanged",
     "collapseUnchangedTooltip": "Show only context around changes (GitHub-style)"

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -47,6 +47,9 @@
     "enableCharDiff": "Surlignage des caractères",
     "enableCharDiffLabel": "Surlignage des caractères",
     "enableCharDiffTooltip": "Surligner les caractères modifiés dans les lignes",
+    "indentHeuristic": "Heuristique d'indentation",
+    "indentHeuristicLabel": "Heuristique d'indentation",
+    "indentHeuristicTooltip": "Affichage diff compatible git (déplace les blocs vers des positions moins indentées)",
     "collapseUnchanged": "Réduire les lignes inchangées",
     "collapseUnchangedLabel": "Réduire les lignes inchangées",
     "collapseUnchangedTooltip": "Afficher uniquement le contexte autour des modifications (style GitHub)"

--- a/src/i18n/locales/id.json
+++ b/src/i18n/locales/id.json
@@ -47,6 +47,9 @@
     "enableCharDiff": "Sorotan karakter",
     "enableCharDiffLabel": "Sorotan karakter",
     "enableCharDiffTooltip": "Sorot karakter yang berubah dalam baris",
+    "indentHeuristic": "Heuristik indentasi",
+    "indentHeuristicLabel": "Heuristik indentasi",
+    "indentHeuristicTooltip": "Tampilan diff kompatibel git (geser blok diff ke posisi indentasi lebih rendah)",
     "collapseUnchanged": "Sembunyikan baris tidak berubah",
     "collapseUnchangedLabel": "Sembunyikan baris tidak berubah",
     "collapseUnchangedTooltip": "Tampilkan hanya konteks di sekitar perubahan (gaya GitHub)"

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -47,6 +47,9 @@
     "enableCharDiff": "文字単位ハイライト",
     "enableCharDiffLabel": "文字単位ハイライト",
     "enableCharDiffTooltip": "変更された文字を行内でハイライト表示",
+    "indentHeuristic": "インデントヒューリスティック",
+    "indentHeuristicLabel": "インデントヒューリスティック",
+    "indentHeuristicTooltip": "git互換の差分表示（差分ブロックをインデントが浅い位置へ移動）",
     "collapseUnchanged": "変更なし行を省略",
     "collapseUnchangedLabel": "変更なし行を省略",
     "collapseUnchangedTooltip": "変更行の前後のみ表示（GitHub風）"

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -47,6 +47,9 @@
     "enableCharDiff": "문자 단위 하이라이트",
     "enableCharDiffLabel": "문자 단위 하이라이트",
     "enableCharDiffTooltip": "줄 내에서 변경된 문자를 하이라이트",
+    "indentHeuristic": "들여쓰기 휴리스틱",
+    "indentHeuristicLabel": "들여쓰기 휴리스틱",
+    "indentHeuristicTooltip": "git 호환 diff 표시 (변경 블록을 들여쓰기가 낮은 위치로 이동)",
     "collapseUnchanged": "변경 없는 행 접기",
     "collapseUnchangedLabel": "변경 없는 행 접기",
     "collapseUnchangedTooltip": "변경 주변의 컨텍스트만 표시 (GitHub 스타일)"

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -47,6 +47,9 @@
     "enableCharDiff": "字符级高亮",
     "enableCharDiffLabel": "字符级高亮",
     "enableCharDiffTooltip": "在行内高亮显示变更的字符",
+    "indentHeuristic": "缩进启发式",
+    "indentHeuristicLabel": "缩进启发式",
+    "indentHeuristicTooltip": "git 兼容差异显示（将差异块移动到缩进较少的位置）",
     "collapseUnchanged": "折叠未更改行",
     "collapseUnchangedLabel": "折叠未更改行",
     "collapseUnchangedTooltip": "仅显示变更周围的内容（GitHub 风格）"

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -47,6 +47,9 @@
     "enableCharDiff": "字元級標示",
     "enableCharDiffLabel": "字元級標示",
     "enableCharDiffTooltip": "在行內標示變更的字元",
+    "indentHeuristic": "縮排啟發式",
+    "indentHeuristicLabel": "縮排啟發式",
+    "indentHeuristicTooltip": "git 相容差異顯示（將差異區塊移至縮排較少的位置）",
     "collapseUnchanged": "摺疊未變更行",
     "collapseUnchangedLabel": "摺疊未變更行",
     "collapseUnchangedTooltip": "僅顯示變更周圍的內容（GitHub 風格）"

--- a/src/services/diffService.ts
+++ b/src/services/diffService.ts
@@ -498,6 +498,8 @@ export class DiffService {
    * Physically apply the slide: swap types between the original Myers position
    * [fromStart, fromEnd) and the new best position starting at toStart.
    * toStart can be < fromStart (backward) or > fromStart (forward).
+   * Line numbers are reassigned afterwards by reassignLineNumbers,
+   * so only the type field needs updating here.
    */
   private static applySlide(
     lines: DiffLine[],
@@ -511,18 +513,16 @@ export class DiffService {
     if (toStart < fromStart) {
       // Backward slide: [toStart, fromStart) unchanged→removed; [toEnd, fromEnd) removed→unchanged
       const shift = fromStart - toStart;
-      const savedNews = Array.from({ length: shift }, (_, j) => lines[toStart + j].newLineNumber);
       for (let j = 0; j < shift; j++) {
-        lines[toStart + j]  = { ...lines[toStart + j],  type: 'removed',   newLineNumber: undefined };
-        lines[toEnd   + j]  = { ...lines[toEnd   + j],  type: 'unchanged', newLineNumber: savedNews[j] };
+        lines[toStart + j] = { ...lines[toStart + j], type: 'removed' };
+        lines[toEnd   + j] = { ...lines[toEnd   + j], type: 'unchanged' };
       }
     } else {
       // Forward slide: [fromEnd, toEnd) unchanged→removed; [fromStart, toStart) removed→unchanged
       const shift = toStart - fromStart;
-      const savedNews = Array.from({ length: shift }, (_, j) => lines[fromEnd + j].newLineNumber);
       for (let j = 0; j < shift; j++) {
-        lines[fromEnd   + j] = { ...lines[fromEnd   + j], type: 'removed',   newLineNumber: undefined };
-        lines[fromStart + j] = { ...lines[fromStart + j], type: 'unchanged', newLineNumber: savedNews[j] };
+        lines[fromEnd   + j] = { ...lines[fromEnd   + j], type: 'removed' };
+        lines[fromStart + j] = { ...lines[fromStart + j], type: 'unchanged' };
       }
     }
   }

--- a/src/services/diffService.ts
+++ b/src/services/diffService.ts
@@ -65,8 +65,9 @@ export class DiffService {
       : this.calculateDiffWithBuiltin(processedOriginal, processedModified);
 
     if (options?.indentHeuristic) {
-      const slidLines = this.applyIndentHeuristic(result.lines);
-      result = { ...result, lines: slidLines };
+      const heuristicLines = this.applyIndentHeuristic(result.lines);
+      const heuristicStats = this.calculateStats(heuristicLines);
+      result = { ...result, lines: heuristicLines, stats: heuristicStats };
     }
 
     if (options?.enableCharDiff) {
@@ -280,150 +281,6 @@ export class DiffService {
   }
 
   /**
-   * Count leading whitespace characters (tab = 4 spaces).
-   */
-  private static getIndentLevel(content: string): number {
-    let indent = 0;
-    for (const ch of content) {
-      if (ch === ' ') indent++;
-      else if (ch === '\t') indent += 4;
-      else break;
-    }
-    return indent;
-  }
-
-  /**
-   * Score for placing a change block at `blockStart`.
-   * Lower score = better: prefer positions after less-indented lines.
-   */
-  private static scorePosition(lines: DiffLine[], blockStart: number): number {
-    if (blockStart > 0 && lines[blockStart - 1].type === 'unchanged') {
-      return this.getIndentLevel(lines[blockStart - 1].content);
-    }
-    return 0;
-  }
-
-  /**
-   * Try to slide a contiguous block of `type` lines within unchanged context.
-   * Modifies `lines` in-place by swapping type between changed and unchanged lines.
-   */
-  private static slideBlock(
-    lines: DiffLine[],
-    blockStart: number,
-    blockEnd: number,
-    type: 'removed' | 'added'
-  ): void {
-    const blockLen = blockEnd - blockStart;
-
-    let bestScore = this.scorePosition(lines, blockStart);
-    let bestPos = blockStart;
-
-    // Try sliding up: line before block must match last line of block
-    let pos = blockStart;
-    while (
-      pos > 0 &&
-      lines[pos - 1].type === 'unchanged' &&
-      lines[pos - 1].content === lines[pos + blockLen - 1].content
-    ) {
-      pos--;
-      const score = this.scorePosition(lines, pos);
-      if (score < bestScore) {
-        bestScore = score;
-        bestPos = pos;
-      }
-    }
-
-    // Try sliding down: line after block must match first line of block
-    pos = blockStart;
-    while (
-      pos + blockLen < lines.length &&
-      lines[pos + blockLen].type === 'unchanged' &&
-      lines[pos + blockLen].content === lines[pos].content
-    ) {
-      pos++;
-      const score = this.scorePosition(lines, pos);
-      if (score < bestScore) {
-        bestScore = score;
-        bestPos = pos;
-      }
-    }
-
-    if (bestPos === blockStart) return;
-
-    if (bestPos < blockStart) {
-      // Slide up by (blockStart - bestPos) positions
-      const shift = blockStart - bestPos;
-      for (let j = 0; j < shift; j++) {
-        const unchangedIdx = blockStart - 1 - j;
-        const changedIdx = blockEnd - 1 - j;
-        lines[unchangedIdx] = { ...lines[unchangedIdx], type };
-        lines[changedIdx] = { ...lines[changedIdx], type: 'unchanged' };
-      }
-    } else {
-      // Slide down by (bestPos - blockStart) positions
-      const shift = bestPos - blockStart;
-      for (let j = 0; j < shift; j++) {
-        const changedIdx = blockStart + j;
-        const unchangedIdx = blockEnd + j;
-        lines[changedIdx] = { ...lines[changedIdx], type: 'unchanged' };
-        lines[unchangedIdx] = { ...lines[unchangedIdx], type };
-      }
-    }
-  }
-
-  /**
-   * Recalculate sequential line numbers after a slide operation.
-   */
-  private static recalculateLineNumbers(lines: DiffLine[]): DiffLine[] {
-    let origNum = 1;
-    let newNum = 1;
-    let globalNum = 1;
-    return lines.map(line => {
-      const updated = { ...line, lineNumber: globalNum++ };
-      if (line.type === 'removed') {
-        updated.originalLineNumber = origNum++;
-        updated.newLineNumber = undefined;
-      } else if (line.type === 'added') {
-        updated.originalLineNumber = undefined;
-        updated.newLineNumber = newNum++;
-      } else {
-        updated.originalLineNumber = origNum++;
-        updated.newLineNumber = newNum++;
-      }
-      return updated;
-    });
-  }
-
-  /**
-   * Apply git-compatible indent heuristic as post-processing.
-   * Slides removed and added blocks to positions with lower indent context
-   * for improved readability (matches git diff --indent-heuristic behavior).
-   */
-  private static applyIndentHeuristic(lines: DiffLine[]): DiffLine[] {
-    const result = lines.map(l => ({ ...l }));
-
-    // Process removed blocks
-    let i = 0;
-    while (i < result.length) {
-      if (result[i].type !== 'removed') { i++; continue; }
-      const start = i;
-      while (i < result.length && result[i].type === 'removed') i++;
-      this.slideBlock(result, start, i, 'removed');
-    }
-
-    // Process added blocks
-    i = 0;
-    while (i < result.length) {
-      if (result[i].type !== 'added') { i++; continue; }
-      const start = i;
-      while (i < result.length && result[i].type === 'added') i++;
-      this.slideBlock(result, start, i, 'added');
-    }
-
-    return this.recalculateLineNumbers(result);
-  }
-
-  /**
    * 差分統計を計算
    */
   private static calculateStats(lines: DiffLine[]): DiffStats {
@@ -510,6 +367,203 @@ export class DiffService {
       modified: modifiedCount,
     };
   }
+
+  // ── Indent Heuristic ──────────────────────────────────────────────────────
+
+  /**
+   * Entry point: apply indent heuristic to a DiffLine array.
+   * Step 1 – fix jsdiff boundary noise (common prefix of removed+added blocks)
+   * Step 2 – git-style indent sliding (prefer lower-indent split points)
+   * Step 3 – reassign sequential line numbers
+   */
+  private static applyIndentHeuristic(lines: DiffLine[]): DiffLine[] {
+    const step1 = this.fixBoundaryNoise(lines);
+    const step2 = this.slideRemovedBlocks(step1);
+    return this.reassignLineNumbers(step2);
+  }
+
+  /**
+   * Fix jsdiff boundary noise: when a removed block is immediately followed by
+   * an added block, and their leading lines share the same content, those shared
+   * lines should be unchanged (not removed+added).
+   */
+  private static fixBoundaryNoise(lines: DiffLine[]): DiffLine[] {
+    const result: DiffLine[] = [];
+    let i = 0;
+
+    while (i < lines.length) {
+      if (lines[i].type !== 'removed') {
+        result.push(lines[i++]);
+        continue;
+      }
+
+      const removedBlock: DiffLine[] = [];
+      while (i < lines.length && lines[i].type === 'removed') removedBlock.push(lines[i++]);
+
+      const addedBlock: DiffLine[] = [];
+      while (i < lines.length && lines[i].type === 'added') addedBlock.push(lines[i++]);
+
+      // Count common prefix lines (same content in both blocks)
+      let k = 0;
+      const minLen = Math.min(removedBlock.length, addedBlock.length);
+      while (k < minLen && removedBlock[k].content === addedBlock[k].content) k++;
+
+      // Convert prefix to unchanged (orig from removed side, new from added side)
+      for (let j = 0; j < k; j++) {
+        result.push({
+          ...removedBlock[j],
+          type: 'unchanged',
+          newLineNumber: addedBlock[j].newLineNumber,
+        });
+      }
+      for (let j = k; j < removedBlock.length; j++) result.push(removedBlock[j]);
+      for (let j = k; j < addedBlock.length; j++) result.push(addedBlock[j]);
+    }
+
+    return result;
+  }
+
+  /**
+   * Git-style indent sliding for removed blocks.
+   * For each removed block, slide to the position where pre-context + post-context
+   * indentation is minimised (most natural split point in the code).
+   */
+  private static slideRemovedBlocks(lines: DiffLine[]): DiffLine[] {
+    const result = lines.map(l => ({ ...l }));
+    const len = result.length;
+    let i = 0;
+
+    while (i < len) {
+      if (result[i].type !== 'removed') { i++; continue; }
+
+      const blockStart = i;
+      while (i < len && result[i].type === 'removed') i++;
+      const blockEnd = i;
+
+      // Skip blocks immediately followed by added (fixBoundaryNoise handles those)
+      if (i < len && result[i].type === 'added') continue;
+
+      // Slide backward as far as the content matches preceding unchanged lines
+      let start = blockStart;
+      let end = blockEnd;
+      while (
+        start > 0 &&
+        result[start - 1].type === 'unchanged' &&
+        result[start - 1].content === result[end - 1].content
+      ) { start--; end--; }
+
+      // Scan forward from backward-most position to find minimum indent score
+      let bestStart = start;
+      let bestScore = this.indentScore(result, start, end, len);
+      let s = start;
+      let e = end;
+
+      while (
+        e < len &&
+        result[e].type === 'unchanged' &&
+        result[s].content === result[e].content
+      ) {
+        s++; e++;
+        const score = this.indentScore(result, s, e, len);
+        if (score < bestScore) { bestScore = score; bestStart = s; }
+      }
+
+      if (bestStart !== blockStart) {
+        this.applySlide(result, blockStart, blockEnd, bestStart);
+      }
+    }
+
+    return result;
+  }
+
+  /** pre-indent + post-indent score for a removed block at [start, end). */
+  private static indentScore(lines: DiffLine[], start: number, end: number, len: number): number {
+    const pre  = start > 0   ? this.lineIndent(lines[start - 1].content) : 0;
+    const post = end   < len ? this.lineIndent(lines[end].content)       : 0;
+    return pre + post;
+  }
+
+  /** Count leading whitespace characters (tabs treated as 4 spaces). */
+  private static lineIndent(content: string): number {
+    let n = 0;
+    for (const ch of content) {
+      if (ch === ' ')  n++;
+      else if (ch === '\t') n += 4;
+      else break;
+    }
+    return n;
+  }
+
+  /**
+   * Physically apply the slide: swap types between the original Myers position
+   * [fromStart, fromEnd) and the new best position starting at toStart.
+   * toStart can be < fromStart (backward) or > fromStart (forward).
+   */
+  private static applySlide(
+    lines: DiffLine[],
+    fromStart: number,
+    fromEnd: number,
+    toStart: number,
+  ): void {
+    const blockSize = fromEnd - fromStart;
+    const toEnd = toStart + blockSize;
+
+    if (toStart < fromStart) {
+      // Backward slide: [toStart, fromStart) unchanged→removed; [toEnd, fromEnd) removed→unchanged
+      const shift = fromStart - toStart;
+      const savedNews = Array.from({ length: shift }, (_, j) => lines[toStart + j].newLineNumber);
+      for (let j = 0; j < shift; j++) {
+        lines[toStart + j]  = { ...lines[toStart + j],  type: 'removed',   newLineNumber: undefined };
+        lines[toEnd   + j]  = { ...lines[toEnd   + j],  type: 'unchanged', newLineNumber: savedNews[j] };
+      }
+    } else {
+      // Forward slide: [fromEnd, toEnd) unchanged→removed; [fromStart, toStart) removed→unchanged
+      const shift = toStart - fromStart;
+      const savedNews = Array.from({ length: shift }, (_, j) => lines[fromEnd + j].newLineNumber);
+      for (let j = 0; j < shift; j++) {
+        lines[fromEnd   + j] = { ...lines[fromEnd   + j], type: 'removed',   newLineNumber: undefined };
+        lines[fromStart + j] = { ...lines[fromStart + j], type: 'unchanged', newLineNumber: savedNews[j] };
+      }
+    }
+  }
+
+  /**
+   * Reassign originalLineNumber, newLineNumber, and lineNumber after heuristic
+   * transformations may have changed which lines are removed/unchanged/added.
+   */
+  private static reassignLineNumbers(lines: DiffLine[]): DiffLine[] {
+    let origNum = 1;
+    let newNum  = 1;
+    let globalNum = 1;
+
+    return lines.map(l => {
+      let originalLineNumber: number | undefined;
+      let newLineNumber: number | undefined;
+
+      switch (l.type) {
+        case 'unchanged':
+          originalLineNumber = origNum++;
+          newLineNumber      = newNum++;
+          break;
+        case 'removed':
+          originalLineNumber = origNum++;
+          newLineNumber      = undefined;
+          break;
+        case 'added':
+          originalLineNumber = undefined;
+          newLineNumber      = newNum++;
+          break;
+        case 'modified':
+          originalLineNumber = origNum++;
+          newLineNumber      = newNum++;
+          break;
+      }
+
+      return { ...l, lineNumber: globalNum++, originalLineNumber, newLineNumber };
+    });
+  }
+
+  // ── End Indent Heuristic ─────────────────────────────────────────────────
 
   /**
    * 差分があるかどうかを判定

--- a/src/services/diffService.ts
+++ b/src/services/diffService.ts
@@ -60,9 +60,14 @@ export class DiffService {
     // Select algorithm
     const algorithm = options?.algorithm ?? this.currentAlgorithm;
 
-    const result = algorithm === 'jsdiff'
+    let result = algorithm === 'jsdiff'
       ? this.calculateDiffWithJsDiff(processedOriginal, processedModified)
       : this.calculateDiffWithBuiltin(processedOriginal, processedModified);
+
+    if (options?.indentHeuristic) {
+      const slidLines = this.applyIndentHeuristic(result.lines);
+      result = { ...result, lines: slidLines };
+    }
 
     if (options?.enableCharDiff) {
       const adjustedStats = this.adjustStatsForCharDiff(result.lines, result.stats);
@@ -272,6 +277,150 @@ export class DiffService {
     }
 
     return lines
+  }
+
+  /**
+   * Count leading whitespace characters (tab = 4 spaces).
+   */
+  private static getIndentLevel(content: string): number {
+    let indent = 0;
+    for (const ch of content) {
+      if (ch === ' ') indent++;
+      else if (ch === '\t') indent += 4;
+      else break;
+    }
+    return indent;
+  }
+
+  /**
+   * Score for placing a change block at `blockStart`.
+   * Lower score = better: prefer positions after less-indented lines.
+   */
+  private static scorePosition(lines: DiffLine[], blockStart: number): number {
+    if (blockStart > 0 && lines[blockStart - 1].type === 'unchanged') {
+      return this.getIndentLevel(lines[blockStart - 1].content);
+    }
+    return 0;
+  }
+
+  /**
+   * Try to slide a contiguous block of `type` lines within unchanged context.
+   * Modifies `lines` in-place by swapping type between changed and unchanged lines.
+   */
+  private static slideBlock(
+    lines: DiffLine[],
+    blockStart: number,
+    blockEnd: number,
+    type: 'removed' | 'added'
+  ): void {
+    const blockLen = blockEnd - blockStart;
+
+    let bestScore = this.scorePosition(lines, blockStart);
+    let bestPos = blockStart;
+
+    // Try sliding up: line before block must match last line of block
+    let pos = blockStart;
+    while (
+      pos > 0 &&
+      lines[pos - 1].type === 'unchanged' &&
+      lines[pos - 1].content === lines[pos + blockLen - 1].content
+    ) {
+      pos--;
+      const score = this.scorePosition(lines, pos);
+      if (score < bestScore) {
+        bestScore = score;
+        bestPos = pos;
+      }
+    }
+
+    // Try sliding down: line after block must match first line of block
+    pos = blockStart;
+    while (
+      pos + blockLen < lines.length &&
+      lines[pos + blockLen].type === 'unchanged' &&
+      lines[pos + blockLen].content === lines[pos].content
+    ) {
+      pos++;
+      const score = this.scorePosition(lines, pos);
+      if (score < bestScore) {
+        bestScore = score;
+        bestPos = pos;
+      }
+    }
+
+    if (bestPos === blockStart) return;
+
+    if (bestPos < blockStart) {
+      // Slide up by (blockStart - bestPos) positions
+      const shift = blockStart - bestPos;
+      for (let j = 0; j < shift; j++) {
+        const unchangedIdx = blockStart - 1 - j;
+        const changedIdx = blockEnd - 1 - j;
+        lines[unchangedIdx] = { ...lines[unchangedIdx], type };
+        lines[changedIdx] = { ...lines[changedIdx], type: 'unchanged' };
+      }
+    } else {
+      // Slide down by (bestPos - blockStart) positions
+      const shift = bestPos - blockStart;
+      for (let j = 0; j < shift; j++) {
+        const changedIdx = blockStart + j;
+        const unchangedIdx = blockEnd + j;
+        lines[changedIdx] = { ...lines[changedIdx], type: 'unchanged' };
+        lines[unchangedIdx] = { ...lines[unchangedIdx], type };
+      }
+    }
+  }
+
+  /**
+   * Recalculate sequential line numbers after a slide operation.
+   */
+  private static recalculateLineNumbers(lines: DiffLine[]): DiffLine[] {
+    let origNum = 1;
+    let newNum = 1;
+    let globalNum = 1;
+    return lines.map(line => {
+      const updated = { ...line, lineNumber: globalNum++ };
+      if (line.type === 'removed') {
+        updated.originalLineNumber = origNum++;
+        updated.newLineNumber = undefined;
+      } else if (line.type === 'added') {
+        updated.originalLineNumber = undefined;
+        updated.newLineNumber = newNum++;
+      } else {
+        updated.originalLineNumber = origNum++;
+        updated.newLineNumber = newNum++;
+      }
+      return updated;
+    });
+  }
+
+  /**
+   * Apply git-compatible indent heuristic as post-processing.
+   * Slides removed and added blocks to positions with lower indent context
+   * for improved readability (matches git diff --indent-heuristic behavior).
+   */
+  private static applyIndentHeuristic(lines: DiffLine[]): DiffLine[] {
+    const result = lines.map(l => ({ ...l }));
+
+    // Process removed blocks
+    let i = 0;
+    while (i < result.length) {
+      if (result[i].type !== 'removed') { i++; continue; }
+      const start = i;
+      while (i < result.length && result[i].type === 'removed') i++;
+      this.slideBlock(result, start, i, 'removed');
+    }
+
+    // Process added blocks
+    i = 0;
+    while (i < result.length) {
+      if (result[i].type !== 'added') { i++; continue; }
+      const start = i;
+      while (i < result.length && result[i].type === 'added') i++;
+      this.slideBlock(result, start, i, 'added');
+    }
+
+    return this.recalculateLineNumbers(result);
   }
 
   /**

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -145,8 +145,8 @@ export interface ComparisonOptions {
   ignoreTrailingNewlines: boolean;
   /** Enable character-level inline diff highlighting */
   enableCharDiff: boolean;
-  /** Apply git-compatible indent heuristic to improve diff readability */
-  indentHeuristic: boolean;
+  /** Apply indent heuristic to slide diff blocks to lower-indented positions (git-compatible) */
+  indentHeuristic?: boolean;
 }
 
 /**

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -145,6 +145,8 @@ export interface ComparisonOptions {
   ignoreTrailingNewlines: boolean;
   /** Enable character-level inline diff highlighting */
   enableCharDiff: boolean;
+  /** Apply git-compatible indent heuristic to improve diff readability */
+  indentHeuristic: boolean;
 }
 
 /**

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -146,7 +146,7 @@ export interface ComparisonOptions {
   /** Enable character-level inline diff highlighting */
   enableCharDiff: boolean;
   /** Apply indent heuristic to slide diff blocks to lower-indented positions (git-compatible) */
-  indentHeuristic?: boolean;
+  indentHeuristic: boolean;
 }
 
 /**

--- a/src/utils/textPreprocessor.ts
+++ b/src/utils/textPreprocessor.ts
@@ -123,7 +123,8 @@ export class TextPreprocessor {
       ignoreCase: false,
       ignoreWhitespace: false,
       ignoreTrailingNewlines: true,  // Default checked
-      enableCharDiff: true  // Default enabled for inline character highlighting
+      enableCharDiff: true,  // Default enabled for inline character highlighting
+      indentHeuristic: true  // Default enabled for git-compatible diff display
     };
   }
   

--- a/src/utils/textPreprocessor.ts
+++ b/src/utils/textPreprocessor.ts
@@ -122,9 +122,8 @@ export class TextPreprocessor {
       sortLines: false,
       ignoreCase: false,
       ignoreWhitespace: false,
-      ignoreTrailingNewlines: true,
-      enableCharDiff: true,
-      indentHeuristic: true
+      ignoreTrailingNewlines: true,  // Default checked
+      enableCharDiff: true  // Default enabled for inline character highlighting
     };
   }
   

--- a/src/utils/textPreprocessor.ts
+++ b/src/utils/textPreprocessor.ts
@@ -122,8 +122,9 @@ export class TextPreprocessor {
       sortLines: false,
       ignoreCase: false,
       ignoreWhitespace: false,
-      ignoreTrailingNewlines: true,  // Default checked
-      enableCharDiff: true  // Default enabled for inline character highlighting
+      ignoreTrailingNewlines: true,
+      enableCharDiff: true,
+      indentHeuristic: true
     };
   }
   


### PR DESCRIPTION
## Summary

Closes #99

Myers差分アルゴリズムの後処理として **Indent Heuristic** を実装し、gitと同等の読みやすい差分表示を実現します。

### 実装内容

- **Category A – jsdiff boundary noise 修正** (`fixBoundaryNoise`):  
  jsdiff が `removed: X, removed: Y, added: X` のように境界ノイズを生成するケースで、共通プレフィックス行を `unchanged` に再分類し正確な差分を表示

- **Category B – git互換インデントスライド** (`slideRemovedBlocks`):  
  等コストの差分位置が複数ある場合、インデントが浅い位置（自然な分割点）にブロックをスライドさせgitと同様の出力を生成

- **UI**: `ComparisonOptionsHorizontal` に `indentHeuristic` チェックボックスを追加（デフォルト有効）

- **i18n**: 8言語（ja/en/ko/zh-TW/zh-CN/id/fr/de）の翻訳ファイルを更新

### 変更前後の比較

```
# 変更前（読みにくい）
  def foo():
-     pass
  def bar():
+     pass

# 変更後（git互換・読みやすい）
  def foo():
      pass
  def bar():
-     pass
+     pass
```

## Test plan

- [ ] `npm test` (vitest) が全テスト通過することを確認
- [ ] `src/__tests__/services/indentHeuristic.test.ts` の全ケース（Category A/B）が通過
- [ ] UIで「インデントヒューリスティック」チェックボックスの表示・動作確認
- [ ] 言語切り替え時に翻訳が正しく表示されることを確認
- [ ] jsdiff/builtin 両アルゴリズムで動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)