### PR TITLE
fix: useDiff フックのエラーメッセージが日本語ハードコードで i18n 未対応

### DIFF
--- a/src/__tests__/hooks/useDiff.test.tsx
+++ b/src/__tests__/hooks/useDiff.test.tsx
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { I18nextProvider } from 'react-i18next'
+import React from 'react'
+import { useDiff } from '../../hooks/useDiff'
+import i18n from '../../i18n/config'
+
+function createWrapper(_language: string) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <I18nextProvider i18n={i18n}>{children}</I18nextProvider>
+  }
+}
+
+describe('useDiff - error message i18n', () => {
+  beforeEach(async () => {
+    await i18n.changeLanguage('ja')
+  })
+
+  it('calculateDiff with no files sets Japanese error message in Japanese mode', async () => {
+    await i18n.changeLanguage('ja')
+    const { result } = renderHook(() => useDiff(), { wrapper: createWrapper('ja') })
+
+    await act(async () => {
+      await result.current.calculateDiff()
+    })
+
+    expect(result.current.error).toBe('比較するファイルまたはテキストを両方選択してください')
+    expect(result.current.error).not.toBe('errors.noFilesSelected')
+  })
+
+  it('calculateDiff with no files sets English error message in English mode', async () => {
+    await i18n.changeLanguage('en')
+    const { result } = renderHook(() => useDiff(), { wrapper: createWrapper('en') })
+
+    await act(async () => {
+      await result.current.calculateDiff()
+    })
+
+    // After fix: should be English, not hardcoded Japanese
+    expect(result.current.error).not.toMatch(/比較するファイル/)
+    expect(result.current.error).not.toBe('errors.noFilesSelected')
+    expect(result.current.error).toBeTruthy()
+  })
+
+  it('calculateDiff with no files sets Korean error message in Korean mode', async () => {
+    await i18n.changeLanguage('ko')
+    const { result } = renderHook(() => useDiff(), { wrapper: createWrapper('ko') })
+
+    await act(async () => {
+      await result.current.calculateDiff()
+    })
+
+    expect(result.current.error).not.toMatch(/比較するファイル/)
+    expect(result.current.error).not.toBe('errors.noFilesSelected')
+    expect(result.current.error).toBeTruthy()
+  })
+})

--- a/src/hooks/useDiff.ts
+++ b/src/hooks/useDiff.ts
@@ -1,4 +1,5 @@
 import { useState, useCallback, useMemo, useEffect } from 'react'
+import { useTranslation } from 'react-i18next'
 import type { FileInfo, DiffResult, DiffLine, ViewMode, InputType, ComparisonOptions } from '../types/types'
 import { DiffService } from '../services/diffService'
 import { TextPreprocessor } from '../utils/textPreprocessor'
@@ -35,6 +36,7 @@ export interface UseDiffReturn extends UseDiffState, UseDiffActions {
 }
 
 export function useDiff(): UseDiffReturn {
+  const { t } = useTranslation()
   const [state, setState] = useState<UseDiffState>({
     originalFile: null,
     modifiedFile: null,
@@ -93,9 +95,9 @@ export function useDiff(): UseDiffReturn {
 
   const calculateDiff = useCallback(async () => {
     if (!state.originalFile || !state.modifiedFile) {
-      setState(prev => ({ 
-        ...prev, 
-        error: '比較するファイルまたはテキストを両方選択してください' 
+      setState(prev => ({
+        ...prev,
+        error: t('errors.noFilesSelected')
       }))
       return
     }
@@ -112,19 +114,19 @@ export function useDiff(): UseDiffReturn {
         state.comparisonOptions
       )
 
-      setState(prev => ({ 
-        ...prev, 
-        diffResult: result, 
-        isProcessing: false 
+      setState(prev => ({
+        ...prev,
+        diffResult: result,
+        isProcessing: false
       }))
     } catch (error) {
-      setState(prev => ({ 
-        ...prev, 
-        error: error instanceof Error ? error.message : '差分の計算に失敗しました',
-        isProcessing: false 
+      setState(prev => ({
+        ...prev,
+        error: t('errors.diffCalculationFailed'),
+        isProcessing: false
       }))
     }
-  }, [state.originalFile, state.modifiedFile, state.comparisonOptions])
+  }, [state.originalFile, state.modifiedFile, state.comparisonOptions, t])
 
   const clearAll = useCallback(() => {
     setState({

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -141,7 +141,9 @@
     "title": "Fehler",
     "copyFailed": "Kopieren fehlgeschlagen",
     "exportFailed": "Export fehlgeschlagen",
-    "fileReadError": "Datei konnte nicht gelesen werden"
+    "fileReadError": "Datei konnte nicht gelesen werden",
+    "noFilesSelected": "Bitte wählen Sie beide Dateien oder Texte zum Vergleichen aus",
+    "diffCalculationFailed": "Differenzberechnung fehlgeschlagen"
   },
   "toast": {
     "copyComplete": "Kopieren abgeschlossen",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -141,7 +141,9 @@
     "title": "Error",
     "copyFailed": "Copy Failed",
     "exportFailed": "Export Failed",
-    "fileReadError": "Failed to read file"
+    "fileReadError": "Failed to read file",
+    "noFilesSelected": "Please select both files or text to compare",
+    "diffCalculationFailed": "Failed to calculate differences"
   },
   "toast": {
     "copyComplete": "Copy Complete",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -141,7 +141,9 @@
     "title": "Erreur",
     "copyFailed": "Échec de la copie",
     "exportFailed": "Échec de l'exportation",
-    "fileReadError": "Échec de la lecture du fichier"
+    "fileReadError": "Échec de la lecture du fichier",
+    "noFilesSelected": "Veuillez sélectionner les deux fichiers ou textes à comparer",
+    "diffCalculationFailed": "Échec du calcul des différences"
   },
   "toast": {
     "copyComplete": "Copie terminée",

--- a/src/i18n/locales/id.json
+++ b/src/i18n/locales/id.json
@@ -141,7 +141,9 @@
     "title": "Kesalahan",
     "copyFailed": "Penyalinan Gagal",
     "exportFailed": "Ekspor Gagal",
-    "fileReadError": "Gagal membaca file"
+    "fileReadError": "Gagal membaca file",
+    "noFilesSelected": "Harap pilih kedua file atau teks untuk dibandingkan",
+    "diffCalculationFailed": "Gagal menghitung perbedaan"
   },
   "toast": {
     "copyComplete": "Penyalinan Selesai",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -141,7 +141,9 @@
     "title": "エラー",
     "copyFailed": "コピー失敗",
     "exportFailed": "エクスポート失敗",
-    "fileReadError": "ファイルの読み込みに失敗しました"
+    "fileReadError": "ファイルの読み込みに失敗しました",
+    "noFilesSelected": "比較するファイルまたはテキストを両方選択してください",
+    "diffCalculationFailed": "差分の計算に失敗しました"
   },
   "toast": {
     "copyComplete": "コピー完了",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -141,7 +141,9 @@
     "title": "오류",
     "copyFailed": "복사 실패",
     "exportFailed": "내보내기 실패",
-    "fileReadError": "파일 읽기 실패"
+    "fileReadError": "파일 읽기 실패",
+    "noFilesSelected": "비교할 파일 또는 텍스트를 모두 선택해 주세요",
+    "diffCalculationFailed": "차이 계산에 실패했습니다"
   },
   "toast": {
     "copyComplete": "복사 완료",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -141,7 +141,9 @@
     "title": "错误",
     "copyFailed": "复制失败",
     "exportFailed": "导出失败",
-    "fileReadError": "读取文件失败"
+    "fileReadError": "读取文件失败",
+    "noFilesSelected": "请选择两个要比较的文件或文本",
+    "diffCalculationFailed": "差异计算失败"
   },
   "toast": {
     "copyComplete": "复制完成",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -141,7 +141,9 @@
     "title": "錯誤",
     "copyFailed": "複製失敗",
     "exportFailed": "匯出失敗",
-    "fileReadError": "讀取檔案失敗"
+    "fileReadError": "讀取檔案失敗",
+    "noFilesSelected": "請選擇兩個要比較的檔案或文字",
+    "diffCalculationFailed": "差異計算失敗"
   },
   "toast": {
     "copyComplete": "複製完成",


### PR DESCRIPTION
Closes #90

## Summary

- `src/hooks/useDiff.ts` に `useTranslation()` を追加し、ハードコードの日本語エラーメッセージを翻訳キー経由に変更
- 8言語すべての `src/i18n/locales/*.json` の `errors` セクションに `noFilesSelected` と `diffCalculationFailed` キーを追加
- `catch` 節は `error.message`（ライブラリ由来で言語不定）の代わりに `t('errors.diffCalculationFailed')` を使用
- 言語切り替え時のエラーメッセージ i18n を検証するテスト (`src/__tests__/hooks/useDiff.test.tsx`) を新規追加

## Test plan

- [ ] `npx vitest run` で全テスト（129件）が PASS することを確認
- [ ] 英語モードでファイル未選択のまま「比較」→ 英語エラーメッセージが表示されることを確認
- [ ] 韓国語モードでファイル未選択のまま「比較」→ 韓国語エラーメッセージが表示されることを確認