### PR TITLE
fix: ErrorBoundaryのエラーメッセージが国際化未対応（8言語すべてで英語表示）

### DIFF
--- a/src/components/common/ErrorBoundary.test.tsx
+++ b/src/components/common/ErrorBoundary.test.tsx
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import i18n from 'i18next';
+import { initReactI18next, I18nextProvider } from 'react-i18next';
+import { ErrorBoundary } from './ErrorBoundary';
+
+const resources = {
+  en: {
+    translation: {
+      errorBoundary: {
+        title: 'Something went wrong',
+        description:
+          'We encountered an unexpected error. This has been logged and will be investigated.',
+        errorDetails: 'Error Details (Development)',
+        retry: 'Try Again',
+        reload: 'Reload Page',
+      },
+    },
+  },
+  ja: {
+    translation: {
+      errorBoundary: {
+        title: '問題が発生しました',
+        description:
+          '予期しないエラーが発生しました。このエラーは記録され、調査されます。',
+        errorDetails: 'エラー詳細（開発用）',
+        retry: '再試行',
+        reload: 'ページを再読み込み',
+      },
+    },
+  },
+};
+
+function setupI18n(lang: string) {
+  i18n.use(initReactI18next).init({
+    resources,
+    lng: lang,
+    fallbackLng: 'en',
+    interpolation: { escapeValue: false },
+  });
+  return i18n;
+}
+
+const ThrowingComponent = ({ shouldThrow }: { shouldThrow: boolean }) => {
+  if (shouldThrow) throw new Error('Test error');
+  return <div>Normal content</div>;
+};
+
+const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+beforeEach(() => {
+  consoleError.mockClear();
+});
+
+describe('ErrorBoundary i18n', () => {
+  it('エラーなし時は子要素をレンダリングする', () => {
+    const i18nInstance = setupI18n('en');
+    render(
+      <I18nextProvider i18n={i18nInstance}>
+        <ErrorBoundary>
+          <ThrowingComponent shouldThrow={false} />
+        </ErrorBoundary>
+      </I18nextProvider>
+    );
+    expect(screen.getByText('Normal content')).toBeInTheDocument();
+  });
+
+  it('英語設定時に英語のエラーメッセージを表示する', () => {
+    const i18nInstance = setupI18n('en');
+    render(
+      <I18nextProvider i18n={i18nInstance}>
+        <ErrorBoundary>
+          <ThrowingComponent shouldThrow={true} />
+        </ErrorBoundary>
+      </I18nextProvider>
+    );
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'We encountered an unexpected error. This has been logged and will be investigated.'
+      )
+    ).toBeInTheDocument();
+    expect(screen.getByText('Try Again')).toBeInTheDocument();
+    expect(screen.getByText('Reload Page')).toBeInTheDocument();
+  });
+
+  it('日本語設定時に日本語のエラーメッセージを表示する', () => {
+    const i18nInstance = setupI18n('ja');
+    render(
+      <I18nextProvider i18n={i18nInstance}>
+        <ErrorBoundary>
+          <ThrowingComponent shouldThrow={true} />
+        </ErrorBoundary>
+      </I18nextProvider>
+    );
+    expect(screen.getByText('問題が発生しました')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        '予期しないエラーが発生しました。このエラーは記録され、調査されます。'
+      )
+    ).toBeInTheDocument();
+    expect(screen.getByText('再試行')).toBeInTheDocument();
+    expect(screen.getByText('ページを再読み込み')).toBeInTheDocument();
+  });
+
+  it('英語設定時にハードコードの英文が直接レンダリングされていないことを確認する', () => {
+    const i18nInstance = setupI18n('ja');
+    render(
+      <I18nextProvider i18n={i18nInstance}>
+        <ErrorBoundary>
+          <ThrowingComponent shouldThrow={true} />
+        </ErrorBoundary>
+      </I18nextProvider>
+    );
+    expect(screen.queryByText('Something went wrong')).not.toBeInTheDocument();
+    expect(screen.queryByText('Try Again')).not.toBeInTheDocument();
+    expect(screen.queryByText('Reload Page')).not.toBeInTheDocument();
+  });
+
+  it('カスタムfallbackが指定されている場合はそれを表示する', () => {
+    const i18nInstance = setupI18n('en');
+    render(
+      <I18nextProvider i18n={i18nInstance}>
+        <ErrorBoundary fallback={<div>Custom fallback</div>}>
+          <ThrowingComponent shouldThrow={true} />
+        </ErrorBoundary>
+      </I18nextProvider>
+    );
+    expect(screen.getByText('Custom fallback')).toBeInTheDocument();
+  });
+
+  it('再試行ボタンで子要素を再レンダリングできる', () => {
+    let shouldThrowNow = true;
+    const DynamicChild = () => {
+      if (shouldThrowNow) throw new Error('Test error');
+      return <div>Normal content</div>;
+    };
+
+    const i18nInstance = setupI18n('en');
+    render(
+      <I18nextProvider i18n={i18nInstance}>
+        <ErrorBoundary>
+          <DynamicChild />
+        </ErrorBoundary>
+      </I18nextProvider>
+    );
+    expect(screen.getByText('Try Again')).toBeInTheDocument();
+
+    shouldThrowNow = false;
+    fireEvent.click(screen.getByText('Try Again'));
+
+    expect(screen.getByText('Normal content')).toBeInTheDocument();
+  });
+});

--- a/src/components/common/ErrorBoundary.tsx
+++ b/src/components/common/ErrorBoundary.tsx
@@ -1,12 +1,15 @@
 import React, { Component, ErrorInfo, ReactNode } from 'react';
+import { withTranslation, WithTranslation } from 'react-i18next';
 import { Button } from '../ui/Button';
 import { Card, CardContent, CardHeader, CardTitle } from '../ui/Card';
 
-interface Props {
+interface OwnProps {
   children: ReactNode;
   fallback?: ReactNode;
   onError?: (error: Error, errorInfo: ErrorInfo) => void;
 }
+
+type Props = OwnProps & WithTranslation;
 
 interface State {
   hasError: boolean;
@@ -14,7 +17,7 @@ interface State {
   errorInfo?: ErrorInfo;
 }
 
-class ErrorBoundary extends Component<Props, State> {
+class ErrorBoundaryInner extends Component<Props, State> {
   constructor(props: Props) {
     super(props);
     this.state = { hasError: false };
@@ -33,12 +36,10 @@ class ErrorBoundary extends Component<Props, State> {
       errorInfo,
     });
 
-    // Call the optional error handler
     if (this.props.onError) {
       this.props.onError(error, errorInfo);
     }
 
-    // Log error to console in development
     if (process.env.NODE_ENV === 'development') {
       console.error('ErrorBoundary caught an error:', error, errorInfo);
     }
@@ -53,13 +54,13 @@ class ErrorBoundary extends Component<Props, State> {
   };
 
   render() {
+    const { t } = this.props;
+
     if (this.state.hasError) {
-      // Custom fallback UI
       if (this.props.fallback) {
         return this.props.fallback;
       }
 
-      // Default error UI
       return (
         <div className="min-h-[400px] flex items-center justify-center p-4">
           <Card className="max-w-md w-full">
@@ -79,18 +80,18 @@ class ErrorBoundary extends Component<Props, State> {
                   />
                 </svg>
               </div>
-              <CardTitle>Something went wrong</CardTitle>
+              <CardTitle>{t('errorBoundary.title')}</CardTitle>
             </CardHeader>
-            
+
             <CardContent className="text-center space-y-4">
               <p className="text-sm text-gray-600">
-                We encountered an unexpected error. This has been logged and will be investigated.
+                {t('errorBoundary.description')}
               </p>
-              
+
               {process.env.NODE_ENV === 'development' && this.state.error && (
                 <details className="text-left">
                   <summary className="text-xs text-gray-500 cursor-pointer hover:text-gray-700 mb-2">
-                    Error Details (Development)
+                    {t('errorBoundary.errorDetails')}
                   </summary>
                   <div className="bg-gray-50 rounded-md p-3 text-xs font-mono text-gray-800 whitespace-pre-wrap border overflow-auto max-h-32">
                     {this.state.error.toString()}
@@ -98,16 +99,16 @@ class ErrorBoundary extends Component<Props, State> {
                   </div>
                 </details>
               )}
-              
+
               <div className="flex flex-col sm:flex-row gap-2 justify-center">
                 <Button variant="primary" onClick={this.handleRetry}>
-                  Try Again
+                  {t('errorBoundary.retry')}
                 </Button>
-                <Button 
-                  variant="secondary" 
+                <Button
+                  variant="secondary"
                   onClick={() => window.location.reload()}
                 >
-                  Reload Page
+                  {t('errorBoundary.reload')}
                 </Button>
               </div>
             </CardContent>
@@ -120,10 +121,12 @@ class ErrorBoundary extends Component<Props, State> {
   }
 }
 
+const ErrorBoundary = withTranslation()(ErrorBoundaryInner);
+
 // HOC wrapper for functional components
 function withErrorBoundary<P extends object>(
   WrappedComponent: React.ComponentType<P>,
-  errorBoundaryProps?: Omit<Props, 'children'>
+  errorBoundaryProps?: Omit<OwnProps, 'children'>
 ) {
   const WithErrorBoundaryComponent = (props: P) => (
     <ErrorBoundary {...errorBoundaryProps}>
@@ -141,11 +144,8 @@ function withErrorBoundary<P extends object>(
 // Hook for error reporting from functional components
 function useErrorHandler() {
   return (error: Error, errorInfo?: ErrorInfo) => {
-    // In a real app, you would send this to your error reporting service
     console.error('Error caught by useErrorHandler:', error, errorInfo);
-    
-    // You could also trigger a toast notification here
-    throw error; // Re-throw to trigger error boundary
+    throw error;
   };
 }
 

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -220,6 +220,13 @@
     "diffComparison": "Unterschiedsvergleich",
     "statisticsLabel": "Statistiken:"
   },
+  "errorBoundary": {
+    "title": "Etwas ist schiefgelaufen",
+    "description": "Ein unerwarteter Fehler ist aufgetreten. Dieser wurde protokolliert und wird untersucht.",
+    "errorDetails": "Fehlerdetails (Entwicklung)",
+    "retry": "Erneut versuchen",
+    "reload": "Seite neu laden"
+  },
   "about": {
     "hero": {
       "tagline": "Texte und Dateien intuitiv vergleichen",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -220,6 +220,13 @@
     "diffComparison": "Diff Comparison",
     "statisticsLabel": "Statistics:"
   },
+  "errorBoundary": {
+    "title": "Something went wrong",
+    "description": "We encountered an unexpected error. This has been logged and will be investigated.",
+    "errorDetails": "Error Details (Development)",
+    "retry": "Try Again",
+    "reload": "Reload Page"
+  },
   "about": {
     "hero": {
       "tagline": "Compare text and files, intuitively",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -220,6 +220,13 @@
     "diffComparison": "Comparaison des différences",
     "statisticsLabel": "Statistiques :"
   },
+  "errorBoundary": {
+    "title": "Une erreur s'est produite",
+    "description": "Nous avons rencontré une erreur inattendue. Elle a été enregistrée et sera examinée.",
+    "errorDetails": "Détails de l'erreur (Développement)",
+    "retry": "Réessayer",
+    "reload": "Recharger la page"
+  },
   "about": {
     "hero": {
       "tagline": "Comparez vos textes et fichiers intuitivement",

--- a/src/i18n/locales/id.json
+++ b/src/i18n/locales/id.json
@@ -220,6 +220,13 @@
     "diffComparison": "Perbandingan Perbedaan",
     "statisticsLabel": "Statistik:"
   },
+  "errorBoundary": {
+    "title": "Terjadi kesalahan",
+    "description": "Kami menemukan kesalahan yang tidak terduga. Ini telah dicatat dan akan diselidiki.",
+    "errorDetails": "Detail Kesalahan (Pengembangan)",
+    "retry": "Coba Lagi",
+    "reload": "Muat Ulang Halaman"
+  },
   "about": {
     "hero": {
       "tagline": "Bandingkan teks dan file secara intuitif",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -220,6 +220,13 @@
     "diffComparison": "差分比較",
     "statisticsLabel": "統計:"
   },
+  "errorBoundary": {
+    "title": "問題が発生しました",
+    "description": "予期しないエラーが発生しました。このエラーは記録され、調査されます。",
+    "errorDetails": "エラー詳細（開発用）",
+    "retry": "再試行",
+    "reload": "ページを再読み込み"
+  },
   "about": {
     "hero": {
       "tagline": "テキスト・ファイルの差分を、直感的に比較",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -220,6 +220,13 @@
     "diffComparison": "차이점 비교",
     "statisticsLabel": "통계:"
   },
+  "errorBoundary": {
+    "title": "문제가 발생했습니다",
+    "description": "예기치 않은 오류가 발생했습니다. 이 오류는 기록되어 조사될 것입니다.",
+    "errorDetails": "오류 세부 정보 (개발용)",
+    "retry": "다시 시도",
+    "reload": "페이지 새로고침"
+  },
   "about": {
     "hero": {
       "tagline": "텍스트와 파일의 차이를 직관적으로 비교",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -220,6 +220,13 @@
     "diffComparison": "差异比较",
     "statisticsLabel": "统计："
   },
+  "errorBoundary": {
+    "title": "发生错误",
+    "description": "遇到了意外错误，此错误已被记录并将进行调查。",
+    "errorDetails": "错误详情（开发环境）",
+    "retry": "重试",
+    "reload": "刷新页面"
+  },
   "about": {
     "hero": {
       "tagline": "直观比较文本和文件的差异",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -220,6 +220,13 @@
     "diffComparison": "差異比較",
     "statisticsLabel": "統計："
   },
+  "errorBoundary": {
+    "title": "發生錯誤",
+    "description": "遇到了意外錯誤，此錯誤已被記錄並將進行調查。",
+    "errorDetails": "錯誤詳情（開發環境）",
+    "retry": "重試",
+    "reload": "重新整理頁面"
+  },
   "about": {
     "hero": {
       "tagline": "直覺比較文字與檔案的差異",


### PR DESCRIPTION
## Summary

- `ErrorBoundary.tsx` の5箇所のハードコード英文を `withTranslation` HOC + `t()` 呼び出しに置き換え
- 8言語すべての翻訳ファイルに `errorBoundary.*` キー（title / description / errorDetails / retry / reload）を追加
- ErrorBoundary のi18n動作を検証する Vitest テストを新規追加（6ケース）

## Test plan

- [ ] `npm test` で全132テストがPASSすること（リグレッションなし）
- [ ] 日本語 `/ja/` でエラー発生時に「問題が発生しました」「再試行」などが日本語で表示されること
- [ ] 英語 `/en/` でエラー発生時に「Something went wrong」「Try Again」が英語で表示されること
- [ ] カスタム `fallback` プロパティが指定された場合はそちらが表示されること
- [ ] 「再試行」ボタンで状態がリセットされ、子要素が再レンダリングされること

Closes #84