### PR TITLE
fix: FileUploadAreaのスクリーンリーダー用ヘルプテキストが英語ハードコードでi18n未対応

### DIFF
--- a/src/__tests__/components/diff/FileUploadArea.test.tsx
+++ b/src/__tests__/components/diff/FileUploadArea.test.tsx
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { FileUploadArea } from '../../../components/diff/FileUploadArea';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const translations: Record<string, string> = {
+        'fileUpload.clear': 'Clear',
+        'fileUpload.browseFile': 'Browse file',
+        'fileUpload.loaded': 'Loaded:',
+        'fileUpload.processing': 'Processing...',
+        'fileUpload.fileInputHelp': 'Select a text file to compare. Supported formats: .txt, .js, .ts, .json, .md, and more.',
+      };
+      return translations[key] ?? key;
+    },
+  }),
+}));
+
+const defaultProps = {
+  title: 'Original Text',
+  placeholder: 'Paste text here...',
+  value: '',
+  onChange: vi.fn(),
+  onFileSelect: vi.fn(),
+  isDragging: false,
+  onDragEnter: vi.fn(),
+  onDragLeave: vi.fn(),
+  onDragOver: vi.fn(),
+  onDrop: vi.fn(),
+};
+
+describe('FileUploadArea', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('スクリーンリーダー用ヘルプテキスト (sr-only)', () => {
+    it('fileUpload.fileInputHelp 翻訳キー経由でヘルプテキストが表示される', () => {
+      render(<FileUploadArea {...defaultProps} />);
+      const helpText = screen.getByText(
+        'Select a text file to compare. Supported formats: .txt, .js, .ts, .json, .md, and more.'
+      );
+      expect(helpText).toBeInTheDocument();
+    });
+
+    it('ヘルプテキストが sr-only クラスを持つ（スクリーンリーダー専用）', () => {
+      render(<FileUploadArea {...defaultProps} />);
+      const helpText = screen.getByText(
+        'Select a text file to compare. Supported formats: .txt, .js, .ts, .json, .md, and more.'
+      );
+      expect(helpText).toHaveClass('sr-only');
+    });
+
+    it('英語ハードコード文字列が残っていない', () => {
+      render(<FileUploadArea {...defaultProps} />);
+      // 旧ハードコード文字列が存在しないことを確認
+      expect(
+        screen.queryByText(
+          'Select a text file to upload. Supported formats include .txt, .js, .jsx, .ts, .tsx, .json, .md, .html, .css, and more.'
+        )
+      ).not.toBeInTheDocument();
+    });
+
+    it('ヘルプテキストが aria-describedby で file input から参照される', () => {
+      render(<FileUploadArea {...defaultProps} />);
+      const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+      expect(fileInput).not.toBeNull();
+      const helpId = fileInput.getAttribute('aria-describedby');
+      expect(helpId).not.toBeNull();
+      const helpEl = document.getElementById(helpId!);
+      expect(helpEl).not.toBeNull();
+      expect(helpEl).toHaveClass('sr-only');
+    });
+  });
+});

--- a/src/components/diff/FileUploadArea.tsx
+++ b/src/components/diff/FileUploadArea.tsx
@@ -193,7 +193,7 @@ export const FileUploadArea: React.FC<FileUploadAreaProps> = memo(({
               </label>
               
               <div id={`${fileInputId}-help`} className="sr-only">
-                Select a text file to upload. Supported formats include .txt, .js, .jsx, .ts, .tsx, .json, .md, .html, .css, and more.
+                {t('fileUpload.fileInputHelp')}
               </div>
             </div>
           </div>

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -19,7 +19,8 @@
     "clear": "Löschen",
     "browseFile": "Datei durchsuchen",
     "loaded": "Geladen:",
-    "processing": "Verarbeitung... Bitte warten."
+    "processing": "Verarbeitung... Bitte warten.",
+    "fileInputHelp": "Wählen Sie eine Textdatei zum Vergleichen aus. Unterstützte Formate: .txt, .js, .jsx, .ts, .tsx, .json, .md, .html, .css und weitere."
   },
   "comparison": {
     "compareButton": "Dateien vergleichen",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -19,7 +19,8 @@
     "clear": "Clear",
     "browseFile": "Browse file",
     "loaded": "Loaded:",
-    "processing": "Processing... Please wait."
+    "processing": "Processing... Please wait.",
+    "fileInputHelp": "Select a text file to compare. Supported formats: .txt, .js, .jsx, .ts, .tsx, .json, .md, .html, .css, and more."
   },
   "comparison": {
     "compareButton": "Compare Files",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -19,7 +19,8 @@
     "clear": "Effacer",
     "browseFile": "Parcourir",
     "loaded": "Chargé :",
-    "processing": "Traitement en cours... Veuillez patienter."
+    "processing": "Traitement en cours... Veuillez patienter.",
+    "fileInputHelp": "Sélectionnez un fichier texte à comparer. Formats pris en charge : .txt, .js, .jsx, .ts, .tsx, .json, .md, .html, .css, et plus."
   },
   "comparison": {
     "compareButton": "Comparer les fichiers",

--- a/src/i18n/locales/id.json
+++ b/src/i18n/locales/id.json
@@ -19,7 +19,8 @@
     "clear": "Hapus",
     "browseFile": "Telusuri file",
     "loaded": "Dimuat:",
-    "processing": "Memproses... Harap tunggu."
+    "processing": "Memproses... Harap tunggu.",
+    "fileInputHelp": "Pilih file teks untuk dibandingkan. Format yang didukung: .txt, .js, .jsx, .ts, .tsx, .json, .md, .html, .css, dan lainnya."
   },
   "comparison": {
     "compareButton": "Bandingkan File",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -19,7 +19,8 @@
     "clear": "クリア",
     "browseFile": "ファイルを参照",
     "loaded": "読み込み済み:",
-    "processing": "処理中...お待ちください。"
+    "processing": "処理中...お待ちください。",
+    "fileInputHelp": "比較するテキストファイルを選択してください。対応形式: .txt, .js, .jsx, .ts, .tsx, .json, .md, .html, .css など。"
   },
   "comparison": {
     "compareButton": "ファイルを比較",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -19,7 +19,8 @@
     "clear": "지우기",
     "browseFile": "파일 찾아보기",
     "loaded": "로드됨:",
-    "processing": "처리 중...잠시 기다려 주세요."
+    "processing": "처리 중...잠시 기다려 주세요.",
+    "fileInputHelp": "비교할 텍스트 파일을 선택하세요. 지원 형식: .txt, .js, .jsx, .ts, .tsx, .json, .md, .html, .css 등."
   },
   "comparison": {
     "compareButton": "파일 비교",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -19,7 +19,8 @@
     "clear": "清除",
     "browseFile": "浏览文件",
     "loaded": "已加载:",
-    "processing": "处理中...请稍候。"
+    "processing": "处理中...请稍候。",
+    "fileInputHelp": "选择要比较的文本文件。支持格式：.txt、.js、.jsx、.ts、.tsx、.json、.md、.html、.css 等。"
   },
   "comparison": {
     "compareButton": "比较文件",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -19,7 +19,8 @@
     "clear": "清除",
     "browseFile": "瀏覽檔案",
     "loaded": "已載入:",
-    "processing": "處理中...請稍候。"
+    "processing": "處理中...請稍候。",
+    "fileInputHelp": "選擇要比較的文字檔案。支援格式：.txt、.js、.jsx、.ts、.tsx、.json、.md、.html、.css 等。"
   },
   "comparison": {
     "compareButton": "比較檔案",


### PR DESCRIPTION
## Summary

- `FileUploadArea.tsx` の `sr-only` ヘルプテキスト（スクリーンリーダー向け説明文）が英語ハードコードのまま i18n 未対応だった問題を修正
- 全8言語の翻訳ファイルに `fileUpload.fileInputHelp` キーを追加
- `FileUploadArea.tsx` のハードコード文字列を `t('fileUpload.fileInputHelp')` に置換
- コンポーネントのテストを追加（sr-only ヘルプテキストの i18n 対応を検証）

## Test plan

- [x] 全8言語（en/ja/ko/zh-TW/zh-CN/id/fr/de）の翻訳ファイルに `fileUpload.fileInputHelp` が追加されている
- [x] `FileUploadArea.tsx` の英語ハードコード文字列が除去されている
- [x] `FileUploadArea.test.tsx` 4テストがすべてPASS
- [x] 既存の130テストすべてがリグレッションなし
- [x] `aria-describedby` で file input からヘルプテキストが正しく参照されることを確認

Closes #85