### PR TITLE
fix: diffExport.tsのエラーをサイレントに握り潰さず呼び出し側に伝播させる

### DIFF
--- a/src/__tests__/utils/diffExport.test.ts
+++ b/src/__tests__/utils/diffExport.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { DiffExporter } from '../../utils/diffExport';
+import { DiffParser } from '../../utils/diffParsing';
+import type { DiffLine } from '../../types/types';
+
+const makeLine = (type: DiffLine['type'], content: string, lineNumber = 1): DiffLine => ({
+  type,
+  content,
+  lineNumber,
+});
+
+const SAMPLE_LINES: DiffLine[] = [
+  makeLine('added', 'new line', 1),
+  makeLine('removed', 'old line', 2),
+  makeLine('unchanged', 'same line', 3),
+];
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('DiffExporter - エラー伝播（console.error で握り潰さない）', () => {
+  it('toPlainText: DiffParser.filterByType が例外を投げた場合、呼び出し側に伝播する', () => {
+    vi.spyOn(DiffParser, 'filterByType').mockImplementation(() => {
+      throw new Error('filterByType error');
+    });
+    expect(() => DiffExporter.toPlainText(SAMPLE_LINES)).toThrow('filterByType error');
+  });
+
+  it('toDiffFormat: DiffParser.filterByType が例外を投げた場合、呼び出し側に伝播する', () => {
+    vi.spyOn(DiffParser, 'filterByType').mockImplementation(() => {
+      throw new Error('filterByType error');
+    });
+    expect(() => DiffExporter.toDiffFormat(SAMPLE_LINES)).toThrow('filterByType error');
+  });
+
+  it('toMarkdown: DiffParser.filterByType が例外を投げた場合、呼び出し側に伝播する', () => {
+    vi.spyOn(DiffParser, 'filterByType').mockImplementation(() => {
+      throw new Error('filterByType error');
+    });
+    expect(() => DiffExporter.toMarkdown(SAMPLE_LINES)).toThrow('filterByType error');
+  });
+
+  it('toHtml: DiffParser.filterByType が例外を投げた場合、呼び出し側に伝播する', () => {
+    vi.spyOn(DiffParser, 'filterByType').mockImplementation(() => {
+      throw new Error('filterByType error');
+    });
+    expect(() => DiffExporter.toHtml(SAMPLE_LINES)).toThrow('filterByType error');
+  });
+
+  it('formatWithHeader: DiffParser.getDiffSummary が例外を投げた場合、呼び出し側に伝播する', () => {
+    vi.spyOn(DiffParser, 'getDiffSummary').mockImplementation(() => {
+      throw new Error('getDiffSummary error');
+    });
+    expect(() => DiffExporter.formatWithHeader(SAMPLE_LINES, { includeHeader: true })).toThrow(
+      'getDiffSummary error'
+    );
+  });
+});
+
+describe('DiffExporter - noDifferencesMessage オプション（i18n対応）', () => {
+  it('toMarkdown: filteredLines が空のとき noDifferencesMessage を使用する', () => {
+    vi.spyOn(DiffParser, 'filterByType').mockReturnValue([]);
+    const result = DiffExporter.toMarkdown(SAMPLE_LINES, {
+      noDifferencesMessage: '差分なし',
+    });
+    expect(result).toContain('差分なし');
+    expect(result).not.toContain('No differences to display');
+  });
+
+  it('toHtml: lines が空のとき noDifferencesMessage を使用する', () => {
+    const result = DiffExporter.toHtml([], {
+      noDifferencesMessage: '差分なし',
+    });
+    expect(result).toContain('差分なし');
+    expect(result).not.toContain('No differences to display');
+  });
+
+  it('toHtml: filteredLines が空のとき noDifferencesMessage を使用する', () => {
+    vi.spyOn(DiffParser, 'filterByType').mockReturnValue([]);
+    const result = DiffExporter.toHtml(SAMPLE_LINES, {
+      noDifferencesMessage: '差分なし',
+    });
+    expect(result).toContain('差分なし');
+    expect(result).not.toContain('No differences to display');
+  });
+
+  it('toMarkdown: noDifferencesMessage 未指定時はハードコード英語を返さない', () => {
+    vi.spyOn(DiffParser, 'filterByType').mockReturnValue([]);
+    const result = DiffExporter.toMarkdown(SAMPLE_LINES);
+    expect(result).not.toContain('No differences to display');
+  });
+
+  it('toHtml: noDifferencesMessage 未指定時はハードコード英語を返さない', () => {
+    const result = DiffExporter.toHtml([]);
+    expect(result).not.toContain('No differences to display');
+  });
+});
+
+describe('DiffExporter - 正常系', () => {
+  it('toPlainText: 行をプレーンテキストに変換する', () => {
+    const result = DiffExporter.toPlainText(SAMPLE_LINES);
+    expect(result).toContain('new line');
+    expect(result).toContain('old line');
+    expect(result).toContain('same line');
+  });
+
+  it('toPlainText: 空の配列は空文字列を返す', () => {
+    expect(DiffExporter.toPlainText([])).toBe('');
+  });
+
+  it('toDiffFormat: diff記号（+/-）を含むテキストを返す', () => {
+    const result = DiffExporter.toDiffFormat(SAMPLE_LINES);
+    expect(result).toContain('+');
+    expect(result).toContain('-');
+  });
+
+  it('toDiffFormat: 空の配列は空文字列を返す', () => {
+    expect(DiffExporter.toDiffFormat([])).toBe('');
+  });
+
+  it('toMarkdown: ```diff コードブロックを含むMarkdownを返す', () => {
+    const result = DiffExporter.toMarkdown(SAMPLE_LINES);
+    expect(result).toContain('```diff');
+    expect(result).toContain('```');
+  });
+
+  it('toMarkdown: 空の配列は空文字列を返す', () => {
+    expect(DiffExporter.toMarkdown([])).toBe('');
+  });
+
+  it('toHtml: HTML構造を含む文字列を返す', () => {
+    const result = DiffExporter.toHtml(SAMPLE_LINES);
+    expect(result).toContain('<div');
+    expect(result).toContain('new line');
+  });
+
+  it('formatWithHeader: ヘッダーなしの場合は format() の結果を返す', () => {
+    const result = DiffExporter.formatWithHeader(SAMPLE_LINES, { includeHeader: false });
+    expect(result).toContain('new line');
+  });
+
+  it('formatWithHeader: Markdownヘッダーを含む文字列を返す', () => {
+    const result = DiffExporter.formatWithHeader(SAMPLE_LINES, {
+      format: 'markdown',
+      filename: 'test.txt',
+      includeHeader: true,
+    });
+    expect(result).toContain('## test.txt');
+  });
+});

--- a/src/utils/diffExport.ts
+++ b/src/utils/diffExport.ts
@@ -18,6 +18,8 @@ export interface DiffFormatOptions {
   selectedTypes?: DiffType[];
   /** Number of context lines to include around changes */
   contextLines?: number;
+  /** User-visible message for the "no differences" case; callers should pass a translated string */
+  noDifferencesMessage?: string;
 }
 
 /**
@@ -79,16 +81,11 @@ export class DiffExporter {
       return '';
     }
     
-    try {
-      const filteredLines = DiffParser.filterByType(lines, selectedTypes);
-      
-      return filteredLines.map(line => 
-        this.formatLine(line, false, includeLineNumbers)
-      ).join('\n');
-    } catch (error) {
-      console.error('Error formatting plain text:', error);
-      return '';
-    }
+    const filteredLines = DiffParser.filterByType(lines, selectedTypes);
+
+    return filteredLines.map(line =>
+      this.formatLine(line, false, includeLineNumbers)
+    ).join('\n');
   }
 
   /**
@@ -107,16 +104,11 @@ export class DiffExporter {
       return '';
     }
     
-    try {
-      const filteredLines = DiffParser.filterByType(lines, selectedTypes);
-      
-      return filteredLines.map(line => 
-        this.formatLine(line, true, includeLineNumbers)
-      ).join('\n');
-    } catch (error) {
-      console.error('Error formatting diff format:', error);
-      return '';
-    }
+    const filteredLines = DiffParser.filterByType(lines, selectedTypes);
+
+    return filteredLines.map(line =>
+      this.formatLine(line, true, includeLineNumbers)
+    ).join('\n');
   }
 
   /**
@@ -135,24 +127,20 @@ export class DiffExporter {
       return '';
     }
 
-    try {
-      const filteredLines = DiffParser.filterByType(lines, selectedTypes);
-      
-      if (filteredLines.length === 0) {
-        return '```\nNo differences to display\n```';
-      }
+    const filteredLines = DiffParser.filterByType(lines, selectedTypes);
 
-      const markdownLines = ['```diff'];
-      filteredLines.forEach(line => {
-        markdownLines.push(this.formatLine(line, true, includeLineNumbers));
-      });
-      markdownLines.push('```');
-      
-      return markdownLines.join('\n');
-    } catch (error) {
-      console.error('Error formatting markdown:', error);
-      return '```\nError formatting diff\n```';
+    if (filteredLines.length === 0) {
+      const msg = options.noDifferencesMessage;
+      return msg ? `\`\`\`\n${msg}\n\`\`\`` : '';
     }
+
+    const markdownLines = ['```diff'];
+    filteredLines.forEach(line => {
+      markdownLines.push(this.formatLine(line, true, includeLineNumbers));
+    });
+    markdownLines.push('```');
+
+    return markdownLines.join('\n');
   }
 
   /**
@@ -168,44 +156,40 @@ export class DiffExporter {
     } = options;
     
     if (!lines || lines.length === 0) {
-      return '<div class="diff-container empty">No differences to display</div>';
+      const msg = options.noDifferencesMessage ?? '';
+      return `<div class="diff-container empty">${escapeHtml(msg)}</div>`;
     }
 
-    try {
-      const filteredLines = DiffParser.filterByType(lines, selectedTypes);
-      
-      if (filteredLines.length === 0) {
-        return '<div class="diff-container empty">No differences to display</div>';
-      }
+    const filteredLines = DiffParser.filterByType(lines, selectedTypes);
 
-      const htmlLines = ['<div class="border rounded-md overflow-visible" role="region" aria-label="Unified Diff">'];
-
-      filteredLines.forEach((line, index) => {
-        const className = getLineClassName(line.type);
-        const symbol = escapeHtml(getPrefixSymbol(line.type));
-        const content = escapeHtml(line.content || '\n');
-        const lineId = `line-${index + 1}`;
-
-        // Matching actual application Unified view structure with Tailwind classes
-        htmlLines.push(
-          `<div class="flex items-start hover:bg-gray-25 transition-colors duration-150" id="${lineId}">` +
-          (includeLineNumbers ? `<div class="flex-shrink-0 w-16 px-2 py-1 text-xs text-gray-500 bg-gray-50 border-r select-none">${line.lineNumber}</div>` : '') +
-          `<div class="flex-1 min-w-0">` +
-          `<div class="${className}">` +
-          `<span class="text-gray-400 select-none mr-2" aria-hidden="true">${symbol}</span>` +
-          `<span class="font-mono text-sm whitespace-pre-wrap diff-line-text">${content}</span>` +
-          '</div>' +
-          '</div>' +
-          '</div>'
-        );
-      });
-
-      htmlLines.push('</div>');
-      return htmlLines.join('\n');
-    } catch (error) {
-      console.error('Error formatting HTML:', error);
-      return '<div class="diff-container error">Error formatting diff</div>';
+    if (filteredLines.length === 0) {
+      const msg = options.noDifferencesMessage ?? '';
+      return `<div class="diff-container empty">${escapeHtml(msg)}</div>`;
     }
+
+    const htmlLines = ['<div class="border rounded-md overflow-visible" role="region" aria-label="Unified Diff">'];
+
+    filteredLines.forEach((line, index) => {
+      const className = getLineClassName(line.type);
+      const symbol = escapeHtml(getPrefixSymbol(line.type));
+      const content = escapeHtml(line.content || '\n');
+      const lineId = `line-${index + 1}`;
+
+      htmlLines.push(
+        `<div class="flex items-start hover:bg-gray-25 transition-colors duration-150" id="${lineId}">` +
+        (includeLineNumbers ? `<div class="flex-shrink-0 w-16 px-2 py-1 text-xs text-gray-500 bg-gray-50 border-r select-none">${line.lineNumber}</div>` : '') +
+        `<div class="flex-1 min-w-0">` +
+        `<div class="${className}">` +
+        `<span class="text-gray-400 select-none mr-2" aria-hidden="true">${symbol}</span>` +
+        `<span class="font-mono text-sm whitespace-pre-wrap diff-line-text">${content}</span>` +
+        '</div>' +
+        '</div>' +
+        '</div>'
+      );
+    });
+
+    htmlLines.push('</div>');
+    return htmlLines.join('\n');
   }
 
   /**
@@ -249,52 +233,47 @@ export class DiffExporter {
       return this.format(lines, options);
     }
 
-    try {
-      const summary = DiffParser.getDiffSummary(lines);
-      const content = this.format(lines, options);
-      const timestamp = new Date().toISOString();
+    const summary = DiffParser.getDiffSummary(lines);
+    const content = this.format(lines, options);
+    const timestamp = new Date().toISOString();
 
-      switch (format) {
-        case 'markdown':
-          return [
-            `## ${filename}`,
-            '',
-            `**Changes:** ${summary}`,
-            `**Generated:** ${timestamp}`,
-            '',
-            content
-          ].join('\n');
+    switch (format) {
+      case 'markdown':
+        return [
+          `## ${filename}`,
+          '',
+          `**Changes:** ${summary}`,
+          `**Generated:** ${timestamp}`,
+          '',
+          content
+        ].join('\n');
 
-        case 'html':
-          return [
-            '<div class="diff-header">',
-            `<h3>${escapeHtml(filename)}</h3>`,
-            `<p><strong>Changes:</strong> ${escapeHtml(summary)}</p>`,
-            `<p><strong>Generated:</strong> ${timestamp}</p>`,
-            '</div>',
-            content
-          ].join('\n');
+      case 'html':
+        return [
+          '<div class="diff-header">',
+          `<h3>${escapeHtml(filename)}</h3>`,
+          `<p><strong>Changes:</strong> ${escapeHtml(summary)}</p>`,
+          `<p><strong>Generated:</strong> ${timestamp}</p>`,
+          '</div>',
+          content
+        ].join('\n');
 
-        case 'diff':
-          return [
-            `--- ${originalFilename}`,
-            `+++ ${modifiedFilename}`,
-            `@@ Changes: ${summary} @@`,
-            content
-          ].join('\n');
+      case 'diff':
+        return [
+          `--- ${originalFilename}`,
+          `+++ ${modifiedFilename}`,
+          `@@ Changes: ${summary} @@`,
+          content
+        ].join('\n');
 
-        case 'plain':
-        default:
-          return [
-            `${filename} (${summary})`,
-            `Generated: ${timestamp}`,
-            '',
-            content
-          ].join('\n');
-      }
-    } catch (error) {
-      console.error('Error formatting with header:', error);
-      return this.format(lines, options);
+      case 'plain':
+      default:
+        return [
+          `${filename} (${summary})`,
+          `Generated: ${timestamp}`,
+          '',
+          content
+        ].join('\n');
     }
   }
 


### PR DESCRIPTION
## Summary

- `src/utils/diffExport.ts` 内の `console.error` 5箇所を削除し、すべての例外を呼び出し側に再スロー
- `toMarkdown` / `toHtml` のハードコード英語フォールバック文字列（`'No differences to display'`、`'Error formatting diff'`）を廃止
- `DiffFormatOptions` に `noDifferencesMessage?: string` を追加し、呼び出し側が翻訳済み文字列を渡せるように対応（`exportLabels.noDifferences` キーは全8言語に既存）
- `formatWithHeader` のサイレントフォールバック（catch で無ヘッダー再フォーマット）を削除し、エラーを伝播

## Test plan

- [x] `src/__tests__/utils/diffExport.test.ts` を新規追加（19テスト: エラー伝播×5、noDifferencesMessage×5、正常系×9）
- [x] 全145テスト PASS 確認（既存テストにリグレッションなし）
- [x] TypeScript 型チェック (`tsc --noEmit`) エラーなし
- [x] 既存の呼び出し側（`HTMLExportButton.tsx` 等）はすでに `try/catch + トースト表示` を持つため影響なし

Closes #87