### PR TITLE
fix: ViewMode の 'split' リテラル重複で UI 経路により state 値が分岐する

### DIFF
--- a/src/__tests__/types/viewMode.test.ts
+++ b/src/__tests__/types/viewMode.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import type { ViewMode } from '../../types/types';
+
+describe('ViewMode', () => {
+  it("'split' は ViewMode に含まれない（廃止済み）", () => {
+    // 'split' が型に存在しないことを実行時に確認する
+    // TypeScript の型チェックで弾かれるが、実行時ガードとしても重要
+    const validModes: ViewMode[] = ['side-by-side', 'unified'];
+    const invalidMode = 'split';
+    expect(validModes).not.toContain(invalidMode);
+  });
+
+  it("同一論理モード 'side-by-side' は常に同じ値で表現される", () => {
+    const fromHomePage: ViewMode = 'side-by-side';
+    const fromDiffPage: ViewMode = 'side-by-side';
+    expect(fromHomePage).toBe(fromDiffPage);
+  });
+
+  it("有効な ViewMode は 'side-by-side' と 'unified' のみ", () => {
+    const validModes: ViewMode[] = ['side-by-side', 'unified'];
+    expect(validModes).toHaveLength(2);
+    expect(validModes).toContain('side-by-side');
+    expect(validModes).toContain('unified');
+  });
+});

--- a/src/components/diff/FileComparisonPanel.tsx
+++ b/src/components/diff/FileComparisonPanel.tsx
@@ -95,9 +95,9 @@ export const FileComparisonPanel: React.FC<FileComparisonPanelProps> = ({
             />
             <div className="flex items-center gap-1 bg-gray-100 rounded-md">
               <button
-                onClick={() => onViewModeChange('split')}
+                onClick={() => onViewModeChange('side-by-side')}
                 className={`p-2 rounded transition-colors ${
-                  viewMode === 'split'
+                  viewMode === 'side-by-side'
                     ? 'bg-white shadow-sm text-primary'
                     : 'text-gray-light hover:text-gray'
                 }`}
@@ -135,7 +135,7 @@ export const FileComparisonPanel: React.FC<FileComparisonPanelProps> = ({
           <div className="max-h-[80vh] overflow-auto border rounded-md">
             <DiffViewer
               lines={diffResult.lines}
-              viewMode={viewMode === 'split' ? 'side-by-side' : viewMode}
+              viewMode={viewMode}
               enableCharDiff={enableCharDiff}
               contextLines={collapseUnchanged ? 3 : undefined}
             />

--- a/src/components/export/HTMLExportButton.tsx
+++ b/src/components/export/HTMLExportButton.tsx
@@ -189,7 +189,7 @@ export const HTMLExportButton: React.FC<HTMLExportButtonProps> = ({
         onPreview={handlePreview}
         isExporting={isExporting}
         suggestedFilename={suggestedFilename}
-        initialViewMode={viewMode === 'split' ? 'side-by-side' : viewMode}
+        initialViewMode={viewMode}
       />
     </>
   );

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -55,7 +55,6 @@
       "label": "Anzeigemodus",
       "sideBySide": "Nebeneinander",
       "unified": "Vereinheitlicht",
-      "split": "Geteilt",
       "sideBySideTitle": "Nebeneinander-Ansicht",
       "unifiedTitle": "Vereinheitlichte Ansicht"
     },

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -55,7 +55,6 @@
       "label": "View Mode",
       "sideBySide": "Side by Side",
       "unified": "Unified",
-      "split": "Split",
       "sideBySideTitle": "Side by Side View",
       "unifiedTitle": "Unified View"
     },

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -55,7 +55,6 @@
       "label": "Mode d'affichage",
       "sideBySide": "Côte à côte",
       "unified": "Unifié",
-      "split": "Divisé",
       "sideBySideTitle": "Vue côte à côte",
       "unifiedTitle": "Vue unifiée"
     },

--- a/src/i18n/locales/id.json
+++ b/src/i18n/locales/id.json
@@ -55,7 +55,6 @@
       "label": "Mode Tampilan",
       "sideBySide": "Berdampingan",
       "unified": "Terpadu",
-      "split": "Terpisah",
       "sideBySideTitle": "Tampilan Berdampingan",
       "unifiedTitle": "Tampilan Terpadu"
     },

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -55,7 +55,6 @@
       "label": "表示モード",
       "sideBySide": "横並び",
       "unified": "統合",
-      "split": "分割",
       "sideBySideTitle": "横並び表示",
       "unifiedTitle": "統合表示"
     },

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -55,7 +55,6 @@
       "label": "보기 모드",
       "sideBySide": "나란히",
       "unified": "통합",
-      "split": "분할",
       "sideBySideTitle": "나란히 보기",
       "unifiedTitle": "통합 보기"
     },

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -55,7 +55,6 @@
       "label": "查看模式",
       "sideBySide": "并排",
       "unified": "统一",
-      "split": "分割",
       "sideBySideTitle": "并排查看",
       "unifiedTitle": "统一查看"
     },

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -55,7 +55,6 @@
       "label": "檢視模式",
       "sideBySide": "並排",
       "unified": "統一",
-      "split": "分割",
       "sideBySideTitle": "並排檢視",
       "unifiedTitle": "統一檢視"
     },

--- a/src/pages/DiffPage.tsx
+++ b/src/pages/DiffPage.tsx
@@ -275,7 +275,7 @@ export const DiffPage: React.FC = () => {
                 <div>
                   <h3 className="text-lg font-semibold text-gray-900 mb-3">{t('diffPage.viewMode')}</h3>
                   <ToggleSwitch
-                    value={viewMode === 'split' ? 'side-by-side' : viewMode}
+                    value={viewMode}
                     options={[
                       { value: 'side-by-side', label: t('diffPage.sideBySide') },
                       { value: 'unified', label: t('diffPage.unified') }
@@ -329,7 +329,7 @@ export const DiffPage: React.FC = () => {
               <div className="overflow-auto">
                 <DiffViewer
                   lines={diffResult.lines}
-                  viewMode={viewMode === 'split' ? 'side-by-side' : viewMode}
+                  viewMode={viewMode}
                 />
               </div>
             )}

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -2,7 +2,7 @@
 export type DiffType = 'added' | 'removed' | 'unchanged' | 'modified';
 
 // 表示モード - Union type for diff viewer display modes
-export type ViewMode = 'side-by-side' | 'unified' | 'split';
+export type ViewMode = 'side-by-side' | 'unified';
 
 // 入力タイプ - Union type for input methods
 export type InputType = 'file' | 'text';


### PR DESCRIPTION
## Summary

- `ViewMode` 型から `'split'` リテラルを削除し、`'side-by-side' | 'unified'` に統一
- `FileComparisonPanel`: `onViewModeChange('split')` を `'side-by-side'` に修正し、変換式 (`=== 'split' ? 'side-by-side' : viewMode`) を削除
- `DiffPage`: `ToggleSwitch` の `value` と `DiffViewer` の `viewMode` 2箇所の変換式を削除
- `HTMLExportButton`: `initialViewMode` の変換式を削除
- 8言語 i18n ファイルから未使用の `diffViewer.viewMode.split` キーを削除
- `ViewMode` の有効値を確認するテストを追加

## Test plan

- [ ] `grep -rn "'split'" src/` の結果が新規追加テスト以外に 0 件であることを確認
- [ ] `make typecheck` 緑
- [ ] `make i18n-check` 緑
- [ ] `make build` 緑
- [ ] vitest 全 129 テスト PASS
- [ ] HomePage と DiffPage の双方で side-by-side ボタンを押した結果が `'side-by-side'` に統一される

Closes #96