### PR TITLE
fix: KeyboardShortcutsHelp が metaKey(Cmd) を表示できない・KeyboardShortcut型が二重定義

### DIFF
--- a/src/__tests__/components/ui/KeyboardShortcutsHelp.test.tsx
+++ b/src/__tests__/components/ui/KeyboardShortcutsHelp.test.tsx
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { KeyboardShortcutsHelp } from '../../../components/ui/KeyboardShortcutsHelp';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const map: Record<string, string> = {
+        'keyboard.title': 'キーボードショートカット',
+      };
+      return map[key] ?? key;
+    },
+  }),
+}));
+
+describe('KeyboardShortcutsHelp', () => {
+  describe('metaKey (Cmd) の表示', () => {
+    it('metaKey=true のショートカットに Cmd が表示される', () => {
+      const shortcuts = [{ key: 'Enter', metaKey: true, description: '比較' }];
+      render(<KeyboardShortcutsHelp shortcuts={shortcuts} />);
+      expect(screen.getByText('Cmd + ENTER')).toBeInTheDocument();
+    });
+
+    it('ctrlKey=true のショートカットに Ctrl が表示される', () => {
+      const shortcuts = [{ key: 'c', ctrlKey: true, description: 'コピー' }];
+      render(<KeyboardShortcutsHelp shortcuts={shortcuts} />);
+      expect(screen.getByText('Ctrl + C')).toBeInTheDocument();
+    });
+
+    it('metaKey なしのショートカットに Cmd は含まれない', () => {
+      const shortcuts = [{ key: 'c', ctrlKey: true, description: 'コピー' }];
+      render(<KeyboardShortcutsHelp shortcuts={shortcuts} />);
+      expect(screen.queryByText(/Cmd/)).not.toBeInTheDocument();
+    });
+  });
+
+  describe('タイトルの i18n 対応', () => {
+    it('タイトルが keyboard.title の翻訳値で表示される', () => {
+      const shortcuts = [{ key: 'Enter', description: '比較' }];
+      render(<KeyboardShortcutsHelp shortcuts={shortcuts} />);
+      expect(screen.getByText('キーボードショートカット')).toBeInTheDocument();
+    });
+
+    it('ハードコードの英語 Keyboard Shortcuts は表示されない', () => {
+      const shortcuts = [{ key: 'Enter', description: '比較' }];
+      render(<KeyboardShortcutsHelp shortcuts={shortcuts} />);
+      expect(screen.queryByText('Keyboard Shortcuts')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('shortcuts が空の場合', () => {
+    it('何も表示しない', () => {
+      const { container } = render(<KeyboardShortcutsHelp shortcuts={[]} />);
+      expect(container.firstChild).toBeNull();
+    });
+  });
+});

--- a/src/components/ui/KeyboardShortcutsHelp.tsx
+++ b/src/components/ui/KeyboardShortcutsHelp.tsx
@@ -1,16 +1,12 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import { Card, CardContent, CardHeader, CardTitle } from './Card';
+import { type KeyboardShortcut, formatShortcut } from '../../hooks/useKeyboardShortcuts';
 
-export interface KeyboardShortcut {
-  key: string;
-  ctrlKey?: boolean;
-  shiftKey?: boolean;
-  altKey?: boolean;
-  description: string;
-}
+type DisplayShortcut = Omit<KeyboardShortcut, 'action' | 'preventDefault'>;
 
 export interface KeyboardShortcutsHelpProps {
-  shortcuts: KeyboardShortcut[];
+  shortcuts: DisplayShortcut[];
   className?: string;
 }
 
@@ -18,14 +14,7 @@ export const KeyboardShortcutsHelp: React.FC<KeyboardShortcutsHelpProps> = ({
   shortcuts,
   className = ''
 }) => {
-  const formatShortcut = (shortcut: KeyboardShortcut) => {
-    const keys = [];
-    if (shortcut.ctrlKey) keys.push('Ctrl');
-    if (shortcut.shiftKey) keys.push('Shift');
-    if (shortcut.altKey) keys.push('Alt');
-    keys.push(shortcut.key.toUpperCase());
-    return keys.join(' + ');
-  };
+  const { t } = useTranslation();
 
   if (shortcuts.length === 0) {
     return null;
@@ -34,7 +23,7 @@ export const KeyboardShortcutsHelp: React.FC<KeyboardShortcutsHelpProps> = ({
   return (
     <Card className={className}>
       <CardHeader>
-        <CardTitle>Keyboard Shortcuts</CardTitle>
+        <CardTitle>{t('keyboard.title')}</CardTitle>
       </CardHeader>
       <CardContent>
         <div className="space-y-2">


### PR DESCRIPTION
Closes #95

## Summary

- `KeyboardShortcutsHelp.tsx` のローカル `KeyboardShortcut` 型と `formatShortcut` 関数を削除し、`useKeyboardShortcuts.ts` からエクスポート済みの型・関数を再利用
- `metaKey: true` のショートカットが `Cmd + KEY` の形式で正しく表示されるよう修正
- `<CardTitle>Keyboard Shortcuts</CardTitle>` のハードコードを `t('keyboard.title')` に置き換えて 8 言語対応

## Changes

- `src/components/ui/KeyboardShortcutsHelp.tsx`: 重複定義を削除、`formatShortcut` と `KeyboardShortcut` を `useKeyboardShortcuts` から import、`useTranslation` 追加
- `src/__tests__/components/ui/KeyboardShortcutsHelp.test.tsx`: 新規テスト追加（metaKey 表示・i18n タイトル・空配列ケース）

## Test plan

- [ ] `metaKey=true` のショートカットに `Cmd + ...` が表示されることを確認
- [ ] `ctrlKey=true` のショートカットに `Ctrl + ...` が表示されることを確認
- [ ] タイトルが翻訳キー `keyboard.title` 経由で表示されることを確認
- [ ] `shortcuts=[]` のとき何も表示されないことを確認
- [ ] `vitest run` で全 132 テストが PASS することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)