### PR TITLE
fix: Modal の document.body.style.overflow 管理が壊れやすい（複数モーダル非対応・元の値を復元しない）

### DIFF
--- a/src/__tests__/components/ui/Modal.test.tsx
+++ b/src/__tests__/components/ui/Modal.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, fireEvent, act } from '@testing-library/react';
+import { render, screen, fireEvent, act, cleanup } from '@testing-library/react';
 import { Modal } from '../../../components/ui/Modal';
 
 vi.mock('react-i18next', () => ({
@@ -64,7 +64,6 @@ describe('Modal', () => {
 
       fireEvent.keyDown(document.activeElement!, { key: 'Tab', shiftKey: false });
 
-      // フォーカストラップにより先頭要素（閉じるボタンまたはFirstボタン）に戻る
       const dialog = screen.getByRole('dialog');
       expect(dialog.contains(document.activeElement)).toBe(true);
       expect(document.activeElement).toBe(buttons[0]);
@@ -133,7 +132,6 @@ describe('Modal', () => {
     it('閉じるボタンの aria-label は翻訳キーを通じて取得される（英語ハードコードでない）', async () => {
       renderModal();
       await act(async () => {});
-      // タイトルがある場合、閉じるボタンが表示される
       const closeButton = screen.getByLabelText('Close modal');
       expect(closeButton).toBeTruthy();
     });
@@ -166,5 +164,91 @@ describe('Modal', () => {
       const dialog = screen.getByRole('dialog');
       expect(dialog.getAttribute('aria-labelledby')).toBe('modal-title');
     });
+  });
+});
+
+describe('Modal - body overflow management', () => {
+  beforeEach(() => {
+    document.body.style.overflow = '';
+    delete document.body.dataset.scrollLockCount;
+    delete document.body.dataset.scrollLockOriginalOverflow;
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('モーダルが閉じている間、body.style.overflow は変化しない', () => {
+    render(<Modal isOpen={false} onClose={() => {}}>content</Modal>);
+    expect(document.body.style.overflow).toBe('');
+  });
+
+  it('モーダルを開くと body.style.overflow が hidden になる', () => {
+    const { rerender } = render(
+      <Modal isOpen={false} onClose={() => {}}>content</Modal>
+    );
+    rerender(<Modal isOpen={true} onClose={() => {}}>content</Modal>);
+    expect(document.body.style.overflow).toBe('hidden');
+  });
+
+  it('モーダルを閉じると body.style.overflow が元の空文字列に戻る（unset ではない）', () => {
+    const { rerender } = render(
+      <Modal isOpen={true} onClose={() => {}}>content</Modal>
+    );
+    expect(document.body.style.overflow).toBe('hidden');
+
+    rerender(<Modal isOpen={false} onClose={() => {}}>content</Modal>);
+    expect(document.body.style.overflow).toBe('');
+  });
+
+  it('body に独自の overflow が指定されていた場合、モーダルを閉じると元の値に戻る', () => {
+    document.body.style.overflow = 'scroll';
+
+    const { rerender } = render(
+      <Modal isOpen={true} onClose={() => {}}>content</Modal>
+    );
+    expect(document.body.style.overflow).toBe('hidden');
+
+    rerender(<Modal isOpen={false} onClose={() => {}}>content</Modal>);
+    expect(document.body.style.overflow).toBe('scroll');
+  });
+
+  it('アンマウント時に body.style.overflow が元の値に戻る', () => {
+    document.body.style.overflow = 'auto';
+
+    const { unmount } = render(
+      <Modal isOpen={true} onClose={() => {}}>content</Modal>
+    );
+    expect(document.body.style.overflow).toBe('hidden');
+
+    unmount();
+    expect(document.body.style.overflow).toBe('auto');
+  });
+
+  it('複数モーダルが開いている場合、1つが閉じてもスクロールはロックされたまま', () => {
+    const { rerender: rerender1 } = render(
+      <Modal isOpen={true} onClose={() => {}}>modal 1</Modal>
+    );
+    render(<Modal isOpen={true} onClose={() => {}}>modal 2</Modal>);
+
+    expect(document.body.style.overflow).toBe('hidden');
+
+    rerender1(<Modal isOpen={false} onClose={() => {}}>modal 1</Modal>);
+
+    expect(document.body.style.overflow).toBe('hidden');
+  });
+
+  it('最後のモーダルが閉じるとスクロールが解放される', () => {
+    const { rerender: rerender1 } = render(
+      <Modal isOpen={true} onClose={() => {}}>modal 1</Modal>
+    );
+    const { rerender: rerender2 } = render(
+      <Modal isOpen={true} onClose={() => {}}>modal 2</Modal>
+    );
+
+    rerender1(<Modal isOpen={false} onClose={() => {}}>modal 1</Modal>);
+    rerender2(<Modal isOpen={false} onClose={() => {}}>modal 2</Modal>);
+
+    expect(document.body.style.overflow).toBe('');
   });
 });

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import { cn } from '../../utils/cn';
 import { useFocusTrap } from '../../hooks/useFocusTrap';
+import { useScrollLock } from '../../hooks/useScrollLock';
 
 export interface ModalProps {
   isOpen: boolean;
@@ -43,17 +44,7 @@ const Modal: React.FC<ModalProps> = ({
     return () => document.removeEventListener('keydown', handleEscape);
   }, [isOpen, onClose, closeOnEscape]);
 
-  useEffect(() => {
-    if (isOpen) {
-      document.body.style.overflow = 'hidden';
-    } else {
-      document.body.style.overflow = 'unset';
-    }
-
-    return () => {
-      document.body.style.overflow = 'unset';
-    };
-  }, [isOpen]);
+  useScrollLock(isOpen);
 
   useFocusTrap(modalRef, isOpen);
 

--- a/src/hooks/useScrollLock.ts
+++ b/src/hooks/useScrollLock.ts
@@ -1,0 +1,26 @@
+import { useEffect } from 'react';
+
+export function useScrollLock(active: boolean): void {
+  useEffect(() => {
+    if (!active) return;
+
+    const count = Number(document.body.dataset.scrollLockCount ?? 0);
+    if (count === 0) {
+      document.body.dataset.scrollLockOriginalOverflow = document.body.style.overflow;
+      document.body.style.overflow = 'hidden';
+    }
+    document.body.dataset.scrollLockCount = String(count + 1);
+
+    return () => {
+      const currentCount = Number(document.body.dataset.scrollLockCount ?? 0);
+      const nextCount = Math.max(0, currentCount - 1);
+      if (nextCount === 0) {
+        document.body.style.overflow = document.body.dataset.scrollLockOriginalOverflow ?? '';
+        delete document.body.dataset.scrollLockCount;
+        delete document.body.dataset.scrollLockOriginalOverflow;
+      } else {
+        document.body.dataset.scrollLockCount = String(nextCount);
+      }
+    };
+  }, [active]);
+}


### PR DESCRIPTION
## Summary

- `useScrollLock` フックを新設し、参照カウント（`document.body.dataset.scrollLockCount`）で複数モーダルを管理
- モーダルを開く前の `overflow` 値を `document.body.dataset.scrollLockOriginalOverflow` に保存し、最後のモーダルが閉じた時のみ元の値を正確に復元
- 冗長な `isOpen=false` 時の `overflow = 'unset'` 代入を除去

## Root Cause

`Modal.tsx` の `useEffect` が `overflow` の元の値を保存せず常に `'unset'` に戻していた。また単純な真偽値分岐のため、複数モーダルが同時に開かれると後発モーダルが閉じた時点でスクロールが解放されてしまう問題があった。

## Test Plan

新規テスト: `src/__tests__/components/ui/Modal.test.tsx`

- [x] モーダルが閉じている間、body.style.overflow は変化しない
- [x] モーダルを開くと body.style.overflow が `hidden` になる
- [x] モーダルを閉じると body.style.overflow が元の空文字列に戻る（`unset` ではない）
- [x] body に独自の overflow が指定されていた場合、モーダルを閉じると元の値に戻る
- [x] アンマウント時に body.style.overflow が元の値に戻る
- [x] 複数モーダルが開いている場合、1つが閉じてもスクロールはロックされたまま
- [x] 最後のモーダルが閉じるとスクロールが解放される

Closes #94