### PR TITLE
fix: FileService / useFileReader のエラーメッセージが日本語ハードコードでi18n未対応

### DIFF
--- a/src/__tests__/hooks/useFileReader.test.tsx
+++ b/src/__tests__/hooks/useFileReader.test.tsx
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useFileReader } from '../../hooks/useFileReader'
+import { FileService, FileServiceError } from '../../services/fileService'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, params?: Record<string, string>) => {
+      if (params && Object.keys(params).length > 0) {
+        return `${key}:${JSON.stringify(params)}`
+      }
+      return key
+    },
+  }),
+}))
+
+const makeFile = (name: string, size: number, type: string): File => {
+  const content = 'x'.repeat(size)
+  return new File([content], name, { type })
+}
+
+describe('useFileReader', () => {
+  it('FileServiceError(fileSizeExceeded) は errors.fileSizeExceeded キーで翻訳される', async () => {
+    vi.spyOn(FileService, 'readFile').mockRejectedValueOnce(
+      new FileServiceError('fileSizeExceeded', { maxSize: '10 MB' })
+    )
+
+    const { result } = renderHook(() => useFileReader())
+    const file = makeFile('big.txt', 100, 'text/plain')
+
+    await act(async () => {
+      await result.current.readFile(file)
+    })
+
+    expect(result.current.error).toBe('errors.fileSizeExceeded:{"maxSize":"10 MB"}')
+  })
+
+  it('FileServiceError(unsupportedFileType) は errors.unsupportedFileType キーで翻訳される', async () => {
+    vi.spyOn(FileService, 'readFile').mockRejectedValueOnce(
+      new FileServiceError('unsupportedFileType')
+    )
+
+    const { result } = renderHook(() => useFileReader())
+    const file = makeFile('virus.exe', 100, 'application/octet-stream')
+
+    await act(async () => {
+      await result.current.readFile(file)
+    })
+
+    expect(result.current.error).toBe('errors.unsupportedFileType')
+  })
+
+  it('不明なエラーは errors.fileReadFailed にフォールバックする', async () => {
+    vi.spyOn(FileService, 'readFile').mockRejectedValueOnce(new Error('unknown'))
+
+    const { result } = renderHook(() => useFileReader())
+    const file = makeFile('test.txt', 100, 'text/plain')
+
+    await act(async () => {
+      await result.current.readFile(file)
+    })
+
+    expect(result.current.error).toBe('errors.fileReadFailed')
+  })
+
+  it('非 Error オブジェクトは errors.fileReadFailed にフォールバックする', async () => {
+    vi.spyOn(FileService, 'readFile').mockRejectedValueOnce('string error')
+
+    const { result } = renderHook(() => useFileReader())
+    const file = makeFile('test.txt', 100, 'text/plain')
+
+    await act(async () => {
+      await result.current.readFile(file)
+    })
+
+    expect(result.current.error).toBe('errors.fileReadFailed')
+  })
+})

--- a/src/__tests__/services/fileService/fileService.test.ts
+++ b/src/__tests__/services/fileService/fileService.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest'
+import { FileService, FileServiceError } from '../../../services/fileService'
+
+const makeFile = (name: string, size: number, type: string): File => {
+  const content = 'x'.repeat(size)
+  return new File([content], name, { type })
+}
+
+describe('FileService.validateFile', () => {
+  it('有効なテキストファイルは isValid: true を返す', () => {
+    const file = makeFile('test.txt', 100, 'text/plain')
+    const result = FileService.validateFile(file)
+    expect(result.isValid).toBe(true)
+    expect(result.errorCode).toBeUndefined()
+  })
+
+  it('10MB超のファイルは fileSizeExceeded エラーコードを返す', () => {
+    const file = makeFile('big.txt', 10 * 1024 * 1024 + 1, 'text/plain')
+    const result = FileService.validateFile(file)
+    expect(result.isValid).toBe(false)
+    expect(result.errorCode).toBe('fileSizeExceeded')
+    expect(result.errorParams).toHaveProperty('maxSize')
+  })
+
+  it('サポート外ファイルは unsupportedFileType エラーコードを返す', () => {
+    const file = makeFile('virus.exe', 100, 'application/octet-stream')
+    const result = FileService.validateFile(file)
+    expect(result.isValid).toBe(false)
+    expect(result.errorCode).toBe('unsupportedFileType')
+  })
+})
+
+describe('FileService.readFile', () => {
+  it('バリデーション失敗時は FileServiceError をスローする', async () => {
+    const file = makeFile('virus.exe', 100, 'application/octet-stream')
+    await expect(FileService.readFile(file)).rejects.toBeInstanceOf(FileServiceError)
+  })
+
+  it('バリデーション失敗の FileServiceError は errorCode を持つ', async () => {
+    const file = makeFile('virus.exe', 100, 'application/octet-stream')
+    try {
+      await FileService.readFile(file)
+    } catch (e) {
+      expect(e).toBeInstanceOf(FileServiceError)
+      expect((e as FileServiceError).code).toBe('unsupportedFileType')
+    }
+  })
+
+  it('fileSizeExceeded の FileServiceError は errorParams.maxSize を持つ', async () => {
+    const file = makeFile('big.txt', 10 * 1024 * 1024 + 1, 'text/plain')
+    try {
+      await FileService.readFile(file)
+    } catch (e) {
+      expect(e).toBeInstanceOf(FileServiceError)
+      expect((e as FileServiceError).code).toBe('fileSizeExceeded')
+      expect((e as FileServiceError).params).toHaveProperty('maxSize')
+    }
+  })
+})

--- a/src/hooks/useFileReader.ts
+++ b/src/hooks/useFileReader.ts
@@ -1,6 +1,7 @@
 import { useState, useCallback } from 'react'
+import { useTranslation } from 'react-i18next'
 import type { FileInfo } from '../types/types'
-import { FileService } from '../services/fileService'
+import { FileService, FileServiceError } from '../services/fileService'
 
 interface UseFileReaderState {
   isReading: boolean
@@ -16,6 +17,7 @@ interface UseFileReaderActions {
 export interface UseFileReaderReturn extends UseFileReaderState, UseFileReaderActions {}
 
 export function useFileReader(): UseFileReaderReturn {
+  const { t } = useTranslation()
   const [state, setState] = useState<UseFileReaderState>({
     isReading: false,
     error: null
@@ -25,6 +27,13 @@ export function useFileReader(): UseFileReaderReturn {
     setState(prev => ({ ...prev, error: null }))
   }, [])
 
+  const getErrorMessage = useCallback((error: unknown): string => {
+    if (error instanceof FileServiceError) {
+      return t(`errors.${error.code}`, error.params ?? {})
+    }
+    return t('errors.fileReadFailed')
+  }, [t])
+
   const readFile = useCallback(async (file: File): Promise<FileInfo | null> => {
     setState(prev => ({ ...prev, isReading: true, error: null }))
 
@@ -33,15 +42,14 @@ export function useFileReader(): UseFileReaderReturn {
       setState(prev => ({ ...prev, isReading: false }))
       return fileInfo
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : 'ファイルの読み込みに失敗しました'
-      setState(prev => ({ 
-        ...prev, 
-        isReading: false, 
-        error: errorMessage 
+      setState(prev => ({
+        ...prev,
+        isReading: false,
+        error: getErrorMessage(error)
       }))
       return null
     }
-  }, [])
+  }, [getErrorMessage])
 
   const readFiles = useCallback(async (files: File[]): Promise<FileInfo[] | null> => {
     setState(prev => ({ ...prev, isReading: true, error: null }))
@@ -51,15 +59,14 @@ export function useFileReader(): UseFileReaderReturn {
       setState(prev => ({ ...prev, isReading: false }))
       return fileInfos
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : 'ファイルの読み込みに失敗しました'
-      setState(prev => ({ 
-        ...prev, 
-        isReading: false, 
-        error: errorMessage 
+      setState(prev => ({
+        ...prev,
+        isReading: false,
+        error: getErrorMessage(error)
       }))
       return null
     }
-  }, [])
+  }, [getErrorMessage])
 
   return {
     ...state,

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -141,7 +141,10 @@
     "title": "Fehler",
     "copyFailed": "Kopieren fehlgeschlagen",
     "exportFailed": "Export fehlgeschlagen",
-    "fileReadError": "Datei konnte nicht gelesen werden",
+    "fileReadFailed": "Datei konnte nicht gelesen werden",
+    "fileReadError": "Beim Lesen der Datei ist ein Fehler aufgetreten",
+    "fileSizeExceeded": "Die Dateigröße überschreitet das Limit ({{maxSize}})",
+    "unsupportedFileType": "Nicht unterstütztes Dateiformat. Es können nur Textdateien hochgeladen werden.",
     "noFilesSelected": "Bitte wählen Sie beide Dateien oder Texte zum Vergleichen aus",
     "diffCalculationFailed": "Differenzberechnung fehlgeschlagen"
   },

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -141,7 +141,10 @@
     "title": "Error",
     "copyFailed": "Copy Failed",
     "exportFailed": "Export Failed",
-    "fileReadError": "Failed to read file",
+    "fileReadFailed": "Failed to read file",
+    "fileReadError": "An error occurred while reading the file",
+    "fileSizeExceeded": "File size exceeds the limit ({{maxSize}})",
+    "unsupportedFileType": "Unsupported file type. Only text files can be uploaded.",
     "noFilesSelected": "Please select both files or text to compare",
     "diffCalculationFailed": "Failed to calculate differences"
   },

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -141,7 +141,10 @@
     "title": "Erreur",
     "copyFailed": "Échec de la copie",
     "exportFailed": "Échec de l'exportation",
-    "fileReadError": "Échec de la lecture du fichier",
+    "fileReadFailed": "Échec de la lecture du fichier",
+    "fileReadError": "Une erreur s'est produite lors de la lecture du fichier",
+    "fileSizeExceeded": "La taille du fichier dépasse la limite ({{maxSize}})",
+    "unsupportedFileType": "Format de fichier non pris en charge. Seuls les fichiers texte peuvent être téléchargés.",
     "noFilesSelected": "Veuillez sélectionner les deux fichiers ou textes à comparer",
     "diffCalculationFailed": "Échec du calcul des différences"
   },

--- a/src/i18n/locales/id.json
+++ b/src/i18n/locales/id.json
@@ -141,7 +141,10 @@
     "title": "Kesalahan",
     "copyFailed": "Penyalinan Gagal",
     "exportFailed": "Ekspor Gagal",
-    "fileReadError": "Gagal membaca file",
+    "fileReadFailed": "Gagal membaca file",
+    "fileReadError": "Terjadi kesalahan saat membaca file",
+    "fileSizeExceeded": "Ukuran file melebihi batas ({{maxSize}})",
+    "unsupportedFileType": "Format file tidak didukung. Hanya file teks yang dapat diunggah.",
     "noFilesSelected": "Harap pilih kedua file atau teks untuk dibandingkan",
     "diffCalculationFailed": "Gagal menghitung perbedaan"
   },

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -141,7 +141,10 @@
     "title": "エラー",
     "copyFailed": "コピー失敗",
     "exportFailed": "エクスポート失敗",
-    "fileReadError": "ファイルの読み込みに失敗しました",
+    "fileReadFailed": "ファイルの読み込みに失敗しました",
+    "fileReadError": "ファイルの読み込み中にエラーが発生しました",
+    "fileSizeExceeded": "ファイルサイズが上限（{{maxSize}}）を超えています",
+    "unsupportedFileType": "サポートされていないファイル形式です。テキストファイルのみアップロード可能です",
     "noFilesSelected": "比較するファイルまたはテキストを両方選択してください",
     "diffCalculationFailed": "差分の計算に失敗しました"
   },

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -141,7 +141,10 @@
     "title": "오류",
     "copyFailed": "복사 실패",
     "exportFailed": "내보내기 실패",
-    "fileReadError": "파일 읽기 실패",
+    "fileReadFailed": "파일 읽기에 실패했습니다",
+    "fileReadError": "파일을 읽는 중 오류가 발생했습니다",
+    "fileSizeExceeded": "파일 크기가 한도({{maxSize}})를 초과합니다",
+    "unsupportedFileType": "지원하지 않는 파일 형식입니다. 텍스트 파일만 업로드 가능합니다.",
     "noFilesSelected": "비교할 파일 또는 텍스트를 모두 선택해 주세요",
     "diffCalculationFailed": "차이 계산에 실패했습니다"
   },

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -141,7 +141,10 @@
     "title": "错误",
     "copyFailed": "复制失败",
     "exportFailed": "导出失败",
-    "fileReadError": "读取文件失败",
+    "fileReadFailed": "读取文件失败",
+    "fileReadError": "读取文件时发生错误",
+    "fileSizeExceeded": "文件大小超过限制（{{maxSize}}）",
+    "unsupportedFileType": "不支持的文件格式。仅可上传文本文件。",
     "noFilesSelected": "请选择两个要比较的文件或文本",
     "diffCalculationFailed": "差异计算失败"
   },

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -141,7 +141,10 @@
     "title": "錯誤",
     "copyFailed": "複製失敗",
     "exportFailed": "匯出失敗",
-    "fileReadError": "讀取檔案失敗",
+    "fileReadFailed": "讀取檔案失敗",
+    "fileReadError": "讀取檔案時發生錯誤",
+    "fileSizeExceeded": "檔案大小超過限制（{{maxSize}}）",
+    "unsupportedFileType": "不支援的檔案格式。僅可上傳文字檔案。",
     "noFilesSelected": "請選擇兩個要比較的檔案或文字",
     "diffCalculationFailed": "差異計算失敗"
   },

--- a/src/services/fileService.ts
+++ b/src/services/fileService.ts
@@ -1,8 +1,25 @@
 import type { FileInfo } from '../types/types'
 
+export type FileErrorCode =
+  | 'fileReadFailed'
+  | 'fileReadError'
+  | 'fileSizeExceeded'
+  | 'unsupportedFileType'
+
+export class FileServiceError extends Error {
+  constructor(
+    public readonly code: FileErrorCode,
+    public readonly params?: Record<string, string>
+  ) {
+    super(code)
+    this.name = 'FileServiceError'
+  }
+}
+
 export interface ValidationResult {
   isValid: boolean
-  error?: string
+  errorCode?: FileErrorCode
+  errorParams?: Record<string, string>
 }
 
 export class FileService {
@@ -23,15 +40,14 @@ export class FileService {
    * ファイルを読み込んでFileInfo形式に変換
    */
   static async readFile(file: File): Promise<FileInfo> {
-    // ファイルバリデーション
     const validation = this.validateFile(file)
     if (!validation.isValid) {
-      throw new Error(validation.error)
+      throw new FileServiceError(validation.errorCode!, validation.errorParams)
     }
 
     return new Promise((resolve, reject) => {
       const reader = new FileReader()
-      
+
       reader.onload = (event) => {
         try {
           const content = event.target?.result as string
@@ -42,15 +58,15 @@ export class FileService {
             lastModified: new Date(file.lastModified)
           }
           resolve(fileInfo)
-        } catch (error) {
-          reject(new Error('ファイルの読み込みに失敗しました'))
+        } catch {
+          reject(new FileServiceError('fileReadFailed'))
         }
       }
-      
+
       reader.onerror = () => {
-        reject(new Error('ファイルの読み込み中にエラーが発生しました'))
+        reject(new FileServiceError('fileReadError'))
       }
-      
+
       reader.readAsText(file, 'UTF-8')
     })
   }
@@ -67,19 +83,18 @@ export class FileService {
    * ファイルのバリデーション
    */
   static validateFile(file: File): ValidationResult {
-    // ファイルサイズチェック
     if (file.size > this.MAX_FILE_SIZE) {
       return {
         isValid: false,
-        error: `ファイルサイズが上限（${this.formatFileSize(this.MAX_FILE_SIZE)}）を超えています`
+        errorCode: 'fileSizeExceeded',
+        errorParams: { maxSize: this.formatFileSize(this.MAX_FILE_SIZE) }
       }
     }
 
-    // ファイルタイプチェック
     if (!this.isTextFile(file)) {
       return {
         isValid: false,
-        error: 'サポートされていないファイル形式です。テキストファイルのみアップロード可能です'
+        errorCode: 'unsupportedFileType'
       }
     }
 


### PR DESCRIPTION
Closes #91

## 変更内容

### 根本原因

`FileService` のバリデーション・読み込みエラーが日本語のハードコード文字列として `Error` オブジェクトに格納され、UI層 (`useFileReader`) がそのメッセージをそのまま表示していた。

### 修正方針

サービス層に i18n を持ち込まず、エラー種別を **コード (enum)** として返し、UI層 (`useFileReader`) で `t()` を使って翻訳する設計を採用。

### 具体的な変更

**`src/services/fileService.ts`**
- `FileErrorCode` 型を追加 (`fileReadFailed` / `fileReadError` / `fileSizeExceeded` / `unsupportedFileType`)
- `FileServiceError` クラスを追加 (code + params を持つ)
- `ValidationResult.error?: string` → `errorCode?: FileErrorCode` + `errorParams?: Record<string, string>` に変更
- ハードコード日本語文字列を `FileServiceError` のスローに置き換え

**`src/hooks/useFileReader.ts`**
- `useTranslation` を追加
- `getErrorMessage()` ヘルパーで `FileServiceError` を受け取り `t('errors.<code>', params)` を返す
- 不明なエラーは `errors.fileReadFailed` にフォールバック

**`src/i18n/locales/*.json` (8言語)**
- `errors.fileReadFailed` / `errors.fileReadError` / `errors.fileSizeExceeded` ({{maxSize}}) / `errors.unsupportedFileType` を全言語に追加

**テスト追加**
- `src/__tests__/services/fileService/fileService.test.ts` — validateFile/readFile のエラーコード検証
- `src/__tests__/hooks/useFileReader.test.tsx` — i18nキー変換の検証 (react-i18next をモック)

## テスト結果

```
Test Files  7 passed (7)
Tests      136 passed (136)
```