### PR TITLE
fix: Modal の body overflow ロックが他のモーダル/初期スタイルを破壊する

### DIFF
--- a/src/components/ui/Modal.test.tsx
+++ b/src/components/ui/Modal.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import { Modal } from './Modal';
+
+describe('Modal - body overflow management', () => {
+  beforeEach(() => {
+    document.body.style.overflow = '';
+  });
+
+  it('sets overflow to hidden when opened', () => {
+    const { rerender } = render(
+      <Modal isOpen={false} onClose={() => {}}>content</Modal>
+    );
+
+    rerender(<Modal isOpen={true} onClose={() => {}}>content</Modal>);
+
+    expect(document.body.style.overflow).toBe('hidden');
+  });
+
+  it('restores previous overflow value when closed (not hardcoded unset)', () => {
+    document.body.style.overflow = 'auto';
+
+    const { rerender } = render(
+      <Modal isOpen={true} onClose={() => {}}>content</Modal>
+    );
+
+    rerender(<Modal isOpen={false} onClose={() => {}}>content</Modal>);
+
+    expect(document.body.style.overflow).toBe('auto');
+  });
+
+  it('restores empty string when no prior overflow was set', () => {
+    document.body.style.overflow = '';
+
+    const { rerender } = render(
+      <Modal isOpen={true} onClose={() => {}}>content</Modal>
+    );
+
+    rerender(<Modal isOpen={false} onClose={() => {}}>content</Modal>);
+
+    expect(document.body.style.overflow).toBe('');
+  });
+
+  it('restores overflow when unmounted while open', () => {
+    document.body.style.overflow = 'scroll';
+
+    const { unmount } = render(
+      <Modal isOpen={true} onClose={() => {}}>content</Modal>
+    );
+
+    expect(document.body.style.overflow).toBe('hidden');
+
+    unmount();
+
+    expect(document.body.style.overflow).toBe('scroll');
+  });
+
+  it('does not release overflow lock when inner modal closes while outer modal is still open', () => {
+    // Outer modal opens: saves '' → sets hidden
+    const { rerender: rerenderInner } = render(
+      <Modal isOpen={true} onClose={() => {}}>outer</Modal>
+    );
+    expect(document.body.style.overflow).toBe('hidden');
+
+    // Inner modal opens: saves 'hidden' → sets hidden (no change)
+    const { rerender: rerenderInner2 } = render(
+      <Modal isOpen={true} onClose={() => {}}>inner</Modal>
+    );
+    expect(document.body.style.overflow).toBe('hidden');
+
+    // Inner modal closes: restores 'hidden' (the value it saved), so outer lock remains
+    rerenderInner2(<Modal isOpen={false} onClose={() => {}}>inner</Modal>);
+
+    expect(document.body.style.overflow).toBe('hidden');
+
+    // Outer modal closes: restores '' (the value it saved)
+    rerenderInner(<Modal isOpen={false} onClose={() => {}}>outer</Modal>);
+
+    expect(document.body.style.overflow).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary

- `Modal.tsx` の `useEffect` が cleanup 時に常に `overflow: 'unset'` を設定していた問題を修正
- モーダルを開く直前の `overflow` 値を保存し、cleanup 時に復元するよう変更
- ネストされたモーダル（外側が開いたまま内側が閉じる）でスクロールロックが解除される問題を解消
- ページ側で意図的に設定していた `overflow` スタイルが Modal の開閉で破壊される問題を解消

## Changes

- `src/components/ui/Modal.tsx`: `isOpen=true` 時のみ副作用を実行し、直前の `overflow` を保存・復元
- `src/components/ui/Modal.test.tsx`: バグを再現するテストを追加（5ケース）

## Test plan

- [x] overflow を hidden に設定（モーダルオープン時）
- [x] クローズ時に元の overflow 値（`auto` 等）を復元する
- [x] 元の overflow が空文字列だった場合も正しく復元する
- [x] アンマウント時にも元の overflow を復元する
- [x] 内側モーダルがクローズしても外側モーダルの overflow:hidden を維持する
- [x] 既存の全テスト（131件）が PASS

Closes #92