### PR TITLE
refactor: エクスポートRenderer群の型安全性改善 - `any`型と`undefined as any`の除去

### DIFF
--- a/src/components/export/HTMLExportDialog.tsx
+++ b/src/components/export/HTMLExportDialog.tsx
@@ -7,7 +7,7 @@ import type { HtmlExportOptions } from '../../services/export';
 /**
  * Default HTML export options
  */
-const DEFAULT_HTML_EXPORT_OPTIONS: Required<HtmlExportOptions> = {
+const DEFAULT_HTML_EXPORT_OPTIONS: HtmlExportOptions = {
   includeLineNumbers: true,
   includeHeader: true,
   includeStats: true,
@@ -15,11 +15,7 @@ const DEFAULT_HTML_EXPORT_OPTIONS: Required<HtmlExportOptions> = {
   differencesOnly: false,
   viewMode: 'side-by-side',
   title: 'BDiff Comparison Report',
-  filename: undefined as any,
-  originalFile: undefined as any,
-  modifiedFile: undefined as any,
   collapseUnchanged: false,
-  labels: undefined as any,
 };
 
 interface HTMLExportDialogProps {

--- a/src/hooks/useDiff.ts
+++ b/src/hooks/useDiff.ts
@@ -1,5 +1,5 @@
 import { useState, useCallback, useMemo, useEffect } from 'react'
-import type { FileInfo, DiffResult, ViewMode, InputType, ComparisonOptions } from '../types/types'
+import type { FileInfo, DiffResult, DiffLine, ViewMode, InputType, ComparisonOptions } from '../types/types'
 import { DiffService } from '../services/diffService'
 import { TextPreprocessor } from '../utils/textPreprocessor'
 
@@ -31,7 +31,7 @@ interface UseDiffActions {
 
 export interface UseDiffReturn extends UseDiffState, UseDiffActions {
   canCalculateDiff: boolean
-  formattedDiff: { original: any[]; modified: any[] } | null
+  formattedDiff: { original: DiffLine[]; modified: DiffLine[] } | null
 }
 
 export function useDiff(): UseDiffReturn {

--- a/src/services/export/renderers/HTMLRenderer.ts
+++ b/src/services/export/renderers/HTMLRenderer.ts
@@ -3,17 +3,20 @@
  * Generates standalone HTML documents from diff results
  */
 
-import type { DiffLine, CharSegment, LineWithSegments } from '../../../types/types';
+import type { DiffLine, CharSegment, LineWithSegments, FileInfo } from '../../../types/types';
 import { isCollapsedBlock, isUnifiedCollapsedBlock } from '../../../types/types';
 import type { HtmlExportOptions, ExportLabels } from '../types';
 import { BaseRenderer } from './BaseRenderer';
 import { TAILWIND_CSS } from '../../tailwindEmbedded';
 import { LinePairingService } from '../../linePairingService';
 
+type HtmlRenderOptions = Required<Omit<HtmlExportOptions, 'filename' | 'originalFile' | 'modifiedFile' | 'labels'>> &
+  Pick<HtmlExportOptions, 'filename' | 'originalFile' | 'modifiedFile' | 'labels'>;
+
 /**
  * Default HTML export options
  */
-const DEFAULT_OPTIONS: Required<HtmlExportOptions> = {
+const DEFAULT_OPTIONS: HtmlRenderOptions = {
   includeLineNumbers: true,
   includeHeader: true,
   includeStats: true,
@@ -21,11 +24,7 @@ const DEFAULT_OPTIONS: Required<HtmlExportOptions> = {
   differencesOnly: false,
   viewMode: 'unified',
   title: 'BDiff Comparison Report',
-  filename: undefined as any,
-  originalFile: undefined as any,
-  modifiedFile: undefined as any,
   collapseUnchanged: false,
-  labels: undefined as any,
 };
 
 /**
@@ -38,7 +37,7 @@ export class HTMLRenderer extends BaseRenderer {
    * Render diff lines to standalone HTML document
    */
   render(lines: DiffLine[], options: HtmlExportOptions = {}): string {
-    const opts = { ...DEFAULT_OPTIONS, ...options };
+    const opts = { ...DEFAULT_OPTIONS, ...options } as HtmlRenderOptions;
     this.hasCharHighlighting = false; // Reset for each render
 
     // Filter lines if differences-only mode is enabled
@@ -74,7 +73,7 @@ export class HTMLRenderer extends BaseRenderer {
    */
   private generateHtmlDocument(
     diffHtml: string,
-    opts: Required<HtmlExportOptions>,
+    opts: HtmlRenderOptions,
     timestamp: string,
     linesToRender: DiffLine[]
   ): string {
@@ -108,8 +107,8 @@ ${this.getEmbeddedCSS(opts.theme)}
    * Generate HTML header section with file metadata
    */
   private generateHeader(
-    originalFile: any,
-    modifiedFile: any,
+    originalFile: FileInfo,
+    modifiedFile: FileInfo,
     timestamp: string,
     labels?: ExportLabels
   ): string {
@@ -216,7 +215,7 @@ ${this.getEmbeddedCSS(opts.theme)}
    */
   private generateUnifiedView(
     lines: DiffLine[],
-    options: Required<HtmlExportOptions>
+    options: HtmlRenderOptions
   ): string {
     if (lines.length === 0) {
       const noDiffText = options.labels?.noDifferences ?? 'No differences to display';
@@ -260,7 +259,7 @@ ${this.getEmbeddedCSS(opts.theme)}
    */
   private generateSideBySideView(
     lines: DiffLine[],
-    options: Required<HtmlExportOptions>
+    options: HtmlRenderOptions
   ): string {
     if (lines.length === 0) {
       const noDiffText = options.labels?.noDifferences ?? 'No differences to display';
@@ -313,7 +312,7 @@ ${this.getEmbeddedCSS(opts.theme)}
    */
   private renderSideBySideCell(
     item: LineWithSegments | null,
-    options: Required<HtmlExportOptions>,
+    options: HtmlRenderOptions,
     side: 'original' | 'modified'
   ): string {
     if (!item) {
@@ -351,7 +350,7 @@ ${this.getEmbeddedCSS(opts.theme)}
    */
   private renderDiffLineWithSegments(
     lineWithSegments: LineWithSegments,
-    options: Required<HtmlExportOptions>
+    options: HtmlRenderOptions
   ): string {
     const { line, segments } = lineWithSegments;
     const typeClass = `diff-line-${line.type}`;

--- a/src/services/export/renderers/MarkdownRenderer.ts
+++ b/src/services/export/renderers/MarkdownRenderer.ts
@@ -3,25 +3,24 @@
  * Generates Markdown-formatted output from diff results
  */
 
-import type { DiffLine } from '../../../types/types';
+import type { DiffLine, FileInfo } from '../../../types/types';
 import type { MarkdownExportOptions, ExportLabels } from '../types';
 import { BaseRenderer } from './BaseRenderer';
+
+type MarkdownRenderOptions = Required<Omit<MarkdownExportOptions, 'filename' | 'originalFile' | 'modifiedFile' | 'labels'>> &
+  Pick<MarkdownExportOptions, 'filename' | 'originalFile' | 'modifiedFile' | 'labels'>;
 
 /**
  * Default markdown export options
  */
-const DEFAULT_OPTIONS: Required<MarkdownExportOptions> = {
+const DEFAULT_OPTIONS: MarkdownRenderOptions = {
   useCodeBlocks: true,
   includeDiffSymbols: true,
-  includeLineNumbers: false, // Less useful in markdown
+  includeLineNumbers: false,
   includeStats: true,
   includeHeader: true,
   title: 'Diff Comparison',
-  filename: undefined as any,
-  originalFile: undefined as any,
-  modifiedFile: undefined as any,
   collapseUnchanged: false,
-  labels: undefined as any,
 };
 
 /**
@@ -32,7 +31,7 @@ export class MarkdownRenderer extends BaseRenderer {
    * Render diff lines to Markdown
    */
   render(lines: DiffLine[], options: MarkdownExportOptions = {}): string {
-    const opts = { ...DEFAULT_OPTIONS, ...options };
+    const opts = { ...DEFAULT_OPTIONS, ...options } as MarkdownRenderOptions;
     const sections: string[] = [];
 
     // Add title
@@ -43,7 +42,7 @@ export class MarkdownRenderer extends BaseRenderer {
 
     // Add header if requested
     if (opts.includeHeader && opts.originalFile && opts.modifiedFile) {
-      sections.push(this.generateHeader(opts));
+      sections.push(this.generateHeader(opts, opts.originalFile, opts.modifiedFile));
       sections.push('');
     }
 
@@ -78,7 +77,7 @@ export class MarkdownRenderer extends BaseRenderer {
   /**
    * Generate header section
    */
-  private generateHeader(opts: Required<MarkdownExportOptions>): string {
+  private generateHeader(opts: MarkdownRenderOptions, originalFile: FileInfo, modifiedFile: FileInfo): string {
     const l = opts.labels ?? {};
     const lines: string[] = [];
 
@@ -88,8 +87,8 @@ export class MarkdownRenderer extends BaseRenderer {
     lines.push('');
     lines.push('| File | Name | Size |');
     lines.push('|------|------|------|');
-    lines.push(`| ${l.original ?? 'Original'} | \`${opts.originalFile.name}\` | ${opts.originalFile.size} bytes |`);
-    lines.push(`| ${l.modified ?? 'Modified'} | \`${opts.modifiedFile.name}\` | ${opts.modifiedFile.size} bytes |`);
+    lines.push(`| ${l.original ?? 'Original'} | \`${originalFile.name}\` | ${originalFile.size} bytes |`);
+    lines.push(`| ${l.modified ?? 'Modified'} | \`${modifiedFile.name}\` | ${modifiedFile.size} bytes |`);
 
     return lines.join('\n');
   }
@@ -122,7 +121,7 @@ export class MarkdownRenderer extends BaseRenderer {
    */
   private generateDiffContent(
     lines: DiffLine[],
-    opts: Required<MarkdownExportOptions>
+    opts: MarkdownRenderOptions
   ): string {
     if (opts.useCodeBlocks) {
       return this.generateCodeBlockDiff(lines, opts);
@@ -136,7 +135,7 @@ export class MarkdownRenderer extends BaseRenderer {
    */
   private generateCodeBlockDiff(
     lines: DiffLine[],
-    opts: Required<MarkdownExportOptions>
+    opts: MarkdownRenderOptions
   ): string {
     const content = lines
       .map(line => {
@@ -154,7 +153,7 @@ export class MarkdownRenderer extends BaseRenderer {
    */
   private generateInlineDiff(
     lines: DiffLine[],
-    opts: Required<MarkdownExportOptions>
+    opts: MarkdownRenderOptions
   ): string {
     return lines
       .map(line => this.formatInlineLine(line, opts))
@@ -164,7 +163,7 @@ export class MarkdownRenderer extends BaseRenderer {
   /**
    * Format a single diff line for inline display
    */
-  private formatInlineLine(line: DiffLine, opts: Required<MarkdownExportOptions>): string {
+  private formatInlineLine(line: DiffLine, opts: MarkdownRenderOptions): string {
     const symbol = opts.includeDiffSymbols ? this.getPrefixSymbol(line.type) : '';
     const content = line.content || '';
 

--- a/src/services/export/renderers/PlainTextRenderer.ts
+++ b/src/services/export/renderers/PlainTextRenderer.ts
@@ -3,25 +3,24 @@
  * Generates plain text output from diff results
  */
 
-import type { DiffLine } from '../../../types/types';
+import type { DiffLine, FileInfo } from '../../../types/types';
 import type { PlainTextExportOptions, ExportLabels } from '../types';
 import { BaseRenderer } from './BaseRenderer';
+
+type PlainTextRenderOptions = Required<Omit<PlainTextExportOptions, 'filename' | 'originalFile' | 'modifiedFile' | 'labels'>> &
+  Pick<PlainTextExportOptions, 'filename' | 'originalFile' | 'modifiedFile' | 'labels'>;
 
 /**
  * Default plain text export options
  */
-const DEFAULT_OPTIONS: Required<PlainTextExportOptions> = {
+const DEFAULT_OPTIONS: PlainTextRenderOptions = {
   includeDiffSymbols: true,
   includeLineNumbers: true,
   includeStats: true,
   includeHeader: true,
   columnWidth: 80,
   title: 'Diff Comparison',
-  filename: undefined as any,
-  originalFile: undefined as any,
-  modifiedFile: undefined as any,
   collapseUnchanged: false,
-  labels: undefined as any,
 };
 
 /**
@@ -32,12 +31,12 @@ export class PlainTextRenderer extends BaseRenderer {
    * Render diff lines to plain text
    */
   render(lines: DiffLine[], options: PlainTextExportOptions = {}): string {
-    const opts = { ...DEFAULT_OPTIONS, ...options };
+    const opts = { ...DEFAULT_OPTIONS, ...options } as PlainTextRenderOptions;
     const sections: string[] = [];
 
     // Add header if requested
     if (opts.includeHeader && opts.originalFile && opts.modifiedFile) {
-      sections.push(this.generateHeader(opts));
+      sections.push(this.generateHeader(opts, opts.originalFile, opts.modifiedFile));
       sections.push(''); // Empty line
     }
 
@@ -74,7 +73,7 @@ export class PlainTextRenderer extends BaseRenderer {
   /**
    * Generate header section
    */
-  private generateHeader(opts: Required<PlainTextExportOptions>): string {
+  private generateHeader(opts: PlainTextRenderOptions, originalFile: FileInfo, modifiedFile: FileInfo): string {
     const l = opts.labels ?? {};
     const lines: string[] = [];
     const title = opts.title || l.diffComparison || 'Diff Comparison';
@@ -84,8 +83,8 @@ export class PlainTextRenderer extends BaseRenderer {
     lines.push('');
     lines.push(`${l.generated ?? 'Generated:'} ${this.formatDate(new Date())}`);
     lines.push('');
-    lines.push(`${l.original ?? 'Original'}:  ${opts.originalFile.name} (${opts.originalFile.size} bytes)`);
-    lines.push(`${l.modified ?? 'Modified'}:  ${opts.modifiedFile.name} (${opts.modifiedFile.size} bytes)`);
+    lines.push(`${l.original ?? 'Original'}:  ${originalFile.name} (${originalFile.size} bytes)`);
+    lines.push(`${l.modified ?? 'Modified'}:  ${modifiedFile.name} (${modifiedFile.size} bytes)`);
 
     return lines.join('\n');
   }
@@ -114,7 +113,7 @@ export class PlainTextRenderer extends BaseRenderer {
    */
   private generateDiffContent(
     lines: DiffLine[],
-    opts: Required<PlainTextExportOptions>
+    opts: PlainTextRenderOptions
   ): string {
     return lines
       .map(line => this.formatLine(line, opts))
@@ -124,7 +123,7 @@ export class PlainTextRenderer extends BaseRenderer {
   /**
    * Format a single diff line
    */
-  private formatLine(line: DiffLine, opts: Required<PlainTextExportOptions>): string {
+  private formatLine(line: DiffLine, opts: PlainTextRenderOptions): string {
     const parts: string[] = [];
 
     // Line number (if enabled)

--- a/src/services/svgDiffRenderer.ts
+++ b/src/services/svgDiffRenderer.ts
@@ -252,7 +252,7 @@ export class SvgDiffRenderer {
     colorScheme: SvgColorScheme
   ): string {
     const colors = this.getLineColors(line.type, colorScheme);
-    const symbol = getPrefixSymbol(line.type as any);
+    const symbol = getPrefixSymbol(line.type);
 
     // Layout constants
     const borderWidth = 4;

--- a/src/utils/diffStyling.ts
+++ b/src/utils/diffStyling.ts
@@ -10,7 +10,7 @@ export class DiffStyler {
    * @deprecated Use getPrefixSymbol from diffRendering.ts instead
    */
   static getDiffSymbol(type: DiffType): string {
-    return getPrefixSymbol(type as any)
+    return getPrefixSymbol(type)
   }
 
   /**


### PR DESCRIPTION
Closes #86

## Summary

- `src/services/export/renderers/` 配下の Renderer 群（HTML/Markdown/PlainText）で `Required<XExportOptions>` を廃止し、truly-optional なフィールド（`filename` / `originalFile` / `modifiedFile` / `labels`）を正しくオプショナルのまま保持するローカル型エイリアス（`HtmlRenderOptions` 等）を定義
- `HTMLRenderer.ts:generateHeader` の `originalFile: any, modifiedFile: any` を `FileInfo` 型に変更
- `HTMLExportDialog.tsx` の `DEFAULT_HTML_EXPORT_OPTIONS` 型を `Required<HtmlExportOptions>` → `HtmlExportOptions` に修正し `undefined as any` を排除
- `useDiff.ts` の `formattedDiff` 戻り値型を `{ original: any[]; modified: any[] }` → `{ original: DiffLine[]; modified: DiffLine[] }` に具体化
- `diffStyling.ts` / `svgDiffRenderer.ts` の `getPrefixSymbol(type as any)` から不要な `as any` キャストを除去（`DiffType` は `DiffLine['type']` と同一型）

## Test plan

- [x] `tsc --noEmit` でコンパイルエラーなし
- [x] `vite build` がエラーなく通る
- [x] `vitest run` で 164 テスト全パス（HTMLRenderer / diffRendering / diffExport 等を含む）
- [x] Export 挙動（HTML/Markdown/PlainText）に変化なし（実装ロジックは変更していない）