### PR TITLE
fix: ToastComponent の setTimeout がアンマウント時にクリーンアップされない

### DIFF
--- a/src/__tests__/components/common/Toast.test.tsx
+++ b/src/__tests__/components/common/Toast.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ToastComponent } from '../../../components/common/Toast';
+import type { Toast } from '../../../components/common/Toast';
+
+const baseToast: Toast = {
+  id: 'test-toast-1',
+  type: 'success',
+  title: 'Test Toast',
+  duration: 5000,
+};
+
+describe('ToastComponent', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('✕ボタンをクリックすると300ms後に onRemove が呼ばれる', () => {
+    const onRemove = vi.fn();
+    render(<ToastComponent toast={baseToast} onRemove={onRemove} />);
+
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(onRemove).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(300);
+    expect(onRemove).toHaveBeenCalledOnce();
+    expect(onRemove).toHaveBeenCalledWith('test-toast-1');
+  });
+
+  it('アンマウント時にタイマーがクリーンアップされ onRemove が呼ばれない', () => {
+    const onRemove = vi.fn();
+    const { unmount } = render(<ToastComponent toast={baseToast} onRemove={onRemove} />);
+
+    fireEvent.click(screen.getByRole('button'));
+
+    // タイマー発火前にアンマウント
+    unmount();
+    vi.advanceTimersByTime(300);
+
+    expect(onRemove).not.toHaveBeenCalled();
+  });
+
+  it('✕ボタンを連打しても onRemove は1回しか呼ばれない', () => {
+    const onRemove = vi.fn();
+    render(<ToastComponent toast={baseToast} onRemove={onRemove} />);
+
+    const button = screen.getByRole('button');
+    fireEvent.click(button);
+    fireEvent.click(button);
+    fireEvent.click(button);
+
+    vi.advanceTimersByTime(300);
+
+    expect(onRemove).toHaveBeenCalledOnce();
+  });
+});

--- a/src/components/common/Toast.tsx
+++ b/src/components/common/Toast.tsx
@@ -128,10 +128,14 @@ interface ToastComponentProps {
 const ToastComponent: React.FC<ToastComponentProps> = ({ toast, onRemove }) => {
   const [isRemoving, setIsRemoving] = useState(false);
 
+  useEffect(() => {
+    if (!isRemoving) return;
+    const timeoutId = setTimeout(() => onRemove(toast.id), 300);
+    return () => clearTimeout(timeoutId);
+  }, [isRemoving, onRemove, toast.id]);
+
   const handleRemove = () => {
     setIsRemoving(true);
-    // Delay actual removal to allow exit animation
-    setTimeout(() => onRemove(toast.id), 300);
   };
 
   const typeStyles = {


### PR DESCRIPTION
Closes #88

## Summary

- `ToastComponent.handleRemove()` 内の `setTimeout` を `useEffect` + クリーンアップ関数パターンに変更
- アンマウント時に `clearTimeout` が呼ばれ、stale コールバックの実行・メモリリークを防止
- `isRemoving` が `true` の状態では常に最新のタイマーが1本だけ走るため、✕ボタン連打による多重タイマー登録も解消

## Test plan

- [x] `アンマウント時にタイマーがクリーンアップされ onRemove が呼ばれない` — 新規テスト追加・PASS
- [x] `✕ボタンをクリックすると300ms後に onRemove が呼ばれる` — 既存動作の維持を確認
- [x] `✕ボタンを連打しても onRemove は1回しか呼ばれない` — 多重登録の防止を確認
- [x] 全テスト 230件 PASS（リグレッションなし）