### PR TITLE
chore: .wt/dev.toml を追加（wt serve 対応）

### DIFF
--- a/.wt/dev.toml
+++ b/.wt/dev.toml
@@ -1,0 +1,5 @@
+# bdiff の dev サーバー定義（wt serve / 起動ボタン用）
+[[services]]
+name = "web"
+cmd = "npm run dev -- --port ${port} --host"
+domain = true


### PR DESCRIPTION
rengotaku/wt#38 の一環。wt serve / 起動ボタンで dev サーバーを割当ポート起動できるようにする。