### PR TITLE
fix: Notion 由来長文 Markdown の diff 表示崩れを修正 (BOM/CRLF/NFC 正規化)

### DIFF
--- a/src/__tests__/services/diffService.test.ts
+++ b/src/__tests__/services/diffService.test.ts
@@ -83,4 +83,39 @@ describe('DiffService', () => {
       expect(total).toBe(result.lines.length);
     });
   });
+
+  describe('calculateDiff - encoding normalization (issue #118)', () => {
+    it('CRLF と LF の混在は差分を生まない', () => {
+      const original = 'line1\r\nline2\r\nline3\r\n';
+      const modified = 'line1\nline2\nline3\n';
+      const result = DiffService.calculateDiff(original, modified, defaultOptions);
+      expect(result.stats.added).toBe(0);
+      expect(result.stats.removed).toBe(0);
+      expect(result.stats.modified).toBe(0);
+    });
+
+    it('先頭 BOM の有無で差分が出ない', () => {
+      const original = '﻿hello\nworld';
+      const modified = 'hello\nworld';
+      const result = DiffService.calculateDiff(original, modified, defaultOptions);
+      expect(result.stats.added).toBe(0);
+      expect(result.stats.removed).toBe(0);
+    });
+
+    it('Unicode NFC / NFD 差では差分を生まない (濁点の合成/分解)', () => {
+      const composed = 'あがい';
+      const decomposed = 'あがい';
+      const result = DiffService.calculateDiff(composed, decomposed, defaultOptions);
+      expect(result.stats.added).toBe(0);
+      expect(result.stats.removed).toBe(0);
+    });
+
+    it('CR のみの改行 (旧 Mac) も LF と等価扱い', () => {
+      const original = 'a\rb\rc';
+      const modified = 'a\nb\nc';
+      const result = DiffService.calculateDiff(original, modified, defaultOptions);
+      expect(result.stats.added).toBe(0);
+      expect(result.stats.removed).toBe(0);
+    });
+  });
 });

--- a/src/services/diffService.ts
+++ b/src/services/diffService.ts
@@ -45,14 +45,15 @@ export class DiffService {
     modified: string,
     options?: DiffCalculationOptions
   ): DiffResult {
-    // Apply preprocessing if options are provided
-    let processedOriginal = original;
-    let processedModified = modified;
+    // Normalize encoding-level differences (BOM / CRLF / Unicode composition)
+    // up front so accidental clipboard artifacts never surface as diffs.
+    let processedOriginal = TextPreprocessor.normalizeForDiff(original);
+    let processedModified = TextPreprocessor.normalizeForDiff(modified);
 
     if (options && TextPreprocessor.hasActiveOptions(options)) {
       [processedOriginal, processedModified] = TextPreprocessor.preprocessTexts(
-        original,
-        modified,
+        processedOriginal,
+        processedModified,
         options
       );
     }

--- a/src/utils/textPreprocessor.ts
+++ b/src/utils/textPreprocessor.ts
@@ -5,6 +5,26 @@ import type { ComparisonOptions } from '../types/types';
  */
 export class TextPreprocessor {
   /**
+   * Encoding-level normalization applied unconditionally before any
+   * user-facing comparison option runs. Rendering-identical text pasted from
+   * different sources (Notion / editors / OS clipboards) can otherwise disagree
+   * on BOM, line endings, or Unicode composition and surface as spurious diffs.
+   *
+   * - Strip a leading UTF-8 BOM (U+FEFF)
+   * - Convert CRLF and stray CR to LF
+   * - Apply NFC canonical composition so combining sequences that render the
+   *   same character compare equal
+   */
+  static normalizeForDiff(text: string): string {
+    if (!text) return text;
+    let out = text;
+    if (out.charCodeAt(0) === 0xfeff) out = out.slice(1);
+    out = out.replace(/\r\n?/g, '\n');
+    out = out.normalize('NFC');
+    return out;
+  }
+
+  /**
    * Apply preprocessing to text based on comparison options
    * @param text - The text to preprocess
    * @param options - Comparison options to apply


### PR DESCRIPTION
## Summary

- Notion からコピーした長文 Markdown 同士の diff で、視覚的に同一な行が「削除→追加」として大量に並ぶ現象を修正
- 原因は BOM / CRLF / Unicode 合成形の違いが行単位比較に混入していたこと
- diff 計算の前段で unconditionally に正規化するよう `TextPreprocessor.normalizeForDiff` を追加し、`DiffService.calculateDiff` の入口で常時適用

## 変更内容

- `src/utils/textPreprocessor.ts`
  - `normalizeForDiff(text)` を新規追加（先頭 U+FEFF BOM 除去 / CRLF・単独 CR → LF / NFC 正規化）
- `src/services/diffService.ts`
  - `calculateDiff` の入口で `normalizeForDiff` を常時適用（ユーザー options より前）
- `src/__tests__/services/diffService.test.ts`
  - CRLF↔LF / BOM 有無 / NFC↔NFD / CR-only の 4 ケースを追加

## 設計判断

- **なぜ options 化しないか**: BOM / CRLF / NFC は表示上まったく区別できない encoding-level 差分。ユーザーが「これは無視したい」と個別に判断する対象ではなく、常に等価扱いすべきもの。オプションに増やすと UI が肥大化し、既定チェックの ON/OFF で挙動が変わる罠が増える
- **NFC を選ぶ理由**: 日本語濁点・半濁点は合成済み (NFC) と分解 (NFD) で見た目が完全一致するが、コード上は別文字列。NFC は Notion / 一般エディタの既定に近く、ここに寄せるのが自然

## Test plan

- [x] `make test` — 234 tests passed（追加 4 tests 含む）
- [x] `make typecheck` — 緑
- [x] `make build` — 緑
- [ ] 実 UI での目視確認（BOM/CRLF は視覚的に区別できないため、機械テストで検証済み。UI 側は encoding-level 差分の非表示化を stats/lines 経由で受け取るのみで、rendering 経路の変更なし）

## Out of Scope

- 記法置換（`<aside>` ↔ `> blockquote` 等）のペアリング改善: 別 issue で扱う
- 長文 1 行のインライン diff 表示改善: 別途検討

Closes #118
