### PR TITLE
fix: side-by-side 表示で右カラム（変更後）の行順が入れ替わる問題を修正

### DIFF
--- a/src/services/__tests__/linePairingService.test.ts
+++ b/src/services/__tests__/linePairingService.test.ts
@@ -1,7 +1,6 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { LinePairingService } from '../linePairingService';
 import type { DiffLine } from '../../types/types';
-import type { MatchingAlgorithm } from '../linePairingService';
 
 /**
  * Helper to create DiffLine objects for testing
@@ -22,55 +21,12 @@ function createLine(
 
 describe('LinePairingService', () => {
   // ========================================
-  // アルゴリズム切り替えテスト
+  // 類似度しきい値設定テスト
   // ========================================
-  describe('アルゴリズム切り替え', () => {
-    let originalAlgorithm: MatchingAlgorithm;
-
-    beforeEach(() => {
-      originalAlgorithm = LinePairingService.getAlgorithm();
-    });
-
-    afterEach(() => {
-      LinePairingService.setAlgorithm(originalAlgorithm);
-    });
-
-    it('デフォルトはgreedyアルゴリズム', () => {
-      LinePairingService.setAlgorithm('greedy'); // reset to default
-      expect(LinePairingService.getAlgorithm()).toBe('greedy');
-    });
-
-    it('recursiveアルゴリズムに切り替え可能', () => {
-      LinePairingService.setAlgorithm('recursive');
-      expect(LinePairingService.getAlgorithm()).toBe('recursive');
-    });
-
-    it('両アルゴリズムで同じ基本ケースが動作する', () => {
-      const lines: DiffLine[] = [
-        createLine('A', 'removed', 1),
-        createLine('B', 'removed', 2),
-        createLine('A', 'added', 3),
-        createLine('B', 'added', 4),
-      ];
-
-      // Greedy
-      LinePairingService.setAlgorithm('greedy');
-      const greedyResult = LinePairingService.pairLinesForSideBySide(lines, false);
-
-      // Recursive
-      LinePairingService.setAlgorithm('recursive');
-      const recursiveResult = LinePairingService.pairLinesForSideBySide(lines, false);
-
-      // Both should produce 2 pairs with A↔A and B↔B
-      expect(greedyResult).toHaveLength(2);
-      expect(recursiveResult).toHaveLength(2);
-
-      expect(greedyResult[0].original?.line.content).toBe('A');
-      expect(greedyResult[0].modified?.line.content).toBe('A');
-      expect(recursiveResult[0].original?.line.content).toBe('A');
-      expect(recursiveResult[0].modified?.line.content).toBe('A');
-    });
-
+  // 注: MatchingAlgorithm / setAlgorithm / getAlgorithm は #120 の修正で
+  // matchByContent ディスパッチャと greedy 実装が削除され、参照箇所が
+  // 無くなったため撤去した（side-by-side の順序保存は選択式にできないため）。
+  describe('類似度しきい値設定', () => {
     it('similarityThresholdを変更可能', () => {
       const original = LinePairingService.getSimilarityThreshold();
 
@@ -79,6 +35,28 @@ describe('LinePairingService', () => {
 
       // Reset
       LinePairingService.setSimilarityThreshold(original);
+    });
+  });
+
+  // ========================================
+  // 基本的なペアリング動作（アルゴリズム切り替えとは無関係の挙動検証）
+  // ========================================
+  describe('基本的なペアリング動作', () => {
+    it('同数の完全一致ブロックはA↔A, B↔Bの順でペアリングされる', () => {
+      const lines: DiffLine[] = [
+        createLine('A', 'removed', 1),
+        createLine('B', 'removed', 2),
+        createLine('A', 'added', 3),
+        createLine('B', 'added', 4),
+      ];
+
+      const result = LinePairingService.pairLinesForSideBySide(lines, false);
+
+      expect(result).toHaveLength(2);
+      expect(result[0].original?.line.content).toBe('A');
+      expect(result[0].modified?.line.content).toBe('A');
+      expect(result[1].original?.line.content).toBe('B');
+      expect(result[1].modified?.line.content).toBe('B');
     });
   });
 
@@ -272,22 +250,27 @@ describe('LinePairingService', () => {
         ]);
       });
 
-      it('unchanged行で区切られたremoved/addedも2パス目でマッチする', () => {
-        // 2パスアプローチにより、離れた位置の類似行もマッチする
+      it('unchanged行を跨いだ2パス目の再マッチは行わない（#120で順序保持のため廃止）', () => {
+        // 旧実装は「2パス目」で unchanged 行を跨いで removed/added を結合していたが、
+        // それは結合先の行を元の位置から動かすことになり、右カラムの行番号が
+        // 単調増加でなくなる（#120）。跨ぎマッチは廃止し、各行は自分の位置に留まる。
         const lines: DiffLine[] = [
           createLine('削除される行', 'removed', 1),
           createLine('変更なしの行', 'unchanged', 2),
-          createLine('削除される行', 'added', 3),  // 同じ内容なのでマッチする
+          createLine('削除される行', 'added', 3),  // 内容は同じだが、もう跨いでマッチしない
         ];
         const result = LinePairingService.pairLinesForSideBySide(lines, false);
 
-        expect(result).toHaveLength(2);
-        // removed と added がマッチしてペアになる
+        expect(result).toHaveLength(3);
+        // removed は単独のまま（unchanged を跨いだ added との結合はしない）
         expect(result[0].original?.line.content).toBe('削除される行');
-        expect(result[0].modified?.line.content).toBe('削除される行');
+        expect(result[0].modified).toBeNull();
         // unchanged
         expect(result[1].original?.line.type).toBe('unchanged');
         expect(result[1].modified?.line.type).toBe('unchanged');
+        // added も単独のまま、自分の位置(unchanged の後)に留まる
+        expect(result[2].original).toBeNull();
+        expect(result[2].modified?.line.content).toBe('削除される行');
       });
 
       it('長いテキストでも正しくマッチング', () => {
@@ -464,7 +447,10 @@ describe('LinePairingService', () => {
         expect(braceRemovedPair?.modified).toBeNull();
       });
 
-      it('有意なテキスト行は引き続き遠隔マッチングされる', () => {
+      it('有意なテキスト行もunchangedを跨いだ遠隔マッチングはされない（#120で順序保持のため廃止）', () => {
+        // #97 時点では「有意なテキストは unchanged を跨いでも遠隔マッチングする」仕様だったが、
+        // #120 の調査でこの遠隔マッチングが右カラムの行順を崩す原因と判明したため廃止された。
+        // 各行は unchanged を跨がず、自分の位置に単独で留まる。
         const lines: DiffLine[] = [
           createLine('マッチすべき有意なテキスト', 'removed', 1),
           createLine('変更なし行', 'unchanged', 2),
@@ -472,12 +458,18 @@ describe('LinePairingService', () => {
         ];
         const result = LinePairingService.pairLinesForSideBySide(lines, false);
 
-        // 有意なテキストは遠隔マッチングされるべき
+        // unchanged を跨いだ結合はもう発生しない
         const matchedPair = result.find(
           p => p.original?.line.content === 'マッチすべき有意なテキスト' &&
                p.modified?.line.content === 'マッチすべき有意なテキスト'
         );
-        expect(matchedPair).toBeDefined();
+        expect(matchedPair).toBeUndefined();
+
+        expect(result).toHaveLength(3);
+        expect(result[0].original?.line.content).toBe('マッチすべき有意なテキスト');
+        expect(result[0].modified).toBeNull();
+        expect(result[2].original).toBeNull();
+        expect(result[2].modified?.line.content).toBe('マッチすべき有意なテキスト');
       });
 
       it('同一ブロック内の空行は位置ベースでペアリングされる', () => {
@@ -522,95 +514,171 @@ describe('LinePairingService', () => {
         expect(result.length).toBeGreaterThan(0);
       });
     });
+
+    // ========================================
+    // H. 行番号単調増加の不変条件（issue #120）
+    // ========================================
+    describe('行番号単調増加の不変条件（issue #120）', () => {
+      /**
+       * 左右いずれのカラムも、行番号が常に単調増加であることを検証する。
+       * git / GitHub の side-by-side と同じ不変条件（issue #120 の受け入れ条件）。
+       */
+      function expectMonotonicLineNumbers(result: ReturnType<typeof LinePairingService.pairLinesForSideBySide>): void {
+        const originalLineNumbers = result
+          .filter(p => p.original !== null)
+          .map(p => p.original!.line.originalLineNumber ?? p.original!.line.lineNumber);
+        for (let i = 1; i < originalLineNumbers.length; i++) {
+          expect(originalLineNumbers[i]).toBeGreaterThan(originalLineNumbers[i - 1]);
+        }
+
+        const modifiedLineNumbers = result
+          .filter(p => p.modified !== null)
+          .map(p => p.modified!.line.newLineNumber ?? p.modified!.line.lineNumber);
+        for (let i = 1; i < modifiedLineNumbers.length; i++) {
+          expect(modifiedLineNumbers[i]).toBeGreaterThan(modifiedLineNumbers[i - 1]);
+        }
+      }
+
+      it('最小再現ケース1: 変更ブロック内のcrossingが解消され、右カラムが1→2の昇順になる', () => {
+        // Issue #120 ケース1
+        // 元: alpha beta gamma one / delta epsilon two
+        // 変更後: delta epsilon two three / alpha beta gamma one four
+        // 修正前は右カラムが 2→1 の順で表示されていた
+        const lines: DiffLine[] = [
+          createLine('alpha beta gamma one', 'removed', 1),
+          createLine('delta epsilon two', 'removed', 2),
+          createLine('delta epsilon two three', 'added', 1),
+          createLine('alpha beta gamma one four', 'added', 2),
+        ];
+        const result = LinePairingService.pairLinesForSideBySide(lines, false);
+
+        expectMonotonicLineNumbers(result);
+
+        const modifiedLineNumbers = result
+          .filter(p => p.modified !== null)
+          .map(p => p.modified!.line.newLineNumber);
+        expect(modifiedLineNumbers).toEqual([1, 2]);
+
+        // 全ての行が失われていないこと
+        expect(result.filter(p => p.original !== null)).toHaveLength(2);
+        expect(result.filter(p => p.modified !== null)).toHaveLength(2);
+      });
+
+      it('最小再現ケース2: unchanged行を跨いだaddedの移動が解消され、右カラムが1→2→3→4の昇順になる', () => {
+        // Issue #120 ケース2
+        // 元: Capistrano deploy notes here / unchanged line
+        // 変更後: unchanged line / brand new section A / brand new section B / Capistrano deploy notes here modified
+        // 修正前は右カラムが 4→1→2→3 の順で表示されていた
+        const lines: DiffLine[] = [
+          { lineNumber: 1, content: 'Capistrano deploy notes here', type: 'removed', originalLineNumber: 1 },
+          { lineNumber: 2, content: 'unchanged line', type: 'unchanged', originalLineNumber: 2, newLineNumber: 1 },
+          { lineNumber: 3, content: 'brand new section A', type: 'added', newLineNumber: 2 },
+          { lineNumber: 4, content: 'brand new section B', type: 'added', newLineNumber: 3 },
+          { lineNumber: 5, content: 'Capistrano deploy notes here modified', type: 'added', newLineNumber: 4 },
+        ];
+        const result = LinePairingService.pairLinesForSideBySide(lines, false);
+
+        expectMonotonicLineNumbers(result);
+
+        const modifiedLineNumbers = result
+          .filter(p => p.modified !== null)
+          .map(p => p.modified!.line.newLineNumber);
+        expect(modifiedLineNumbers).toEqual([1, 2, 3, 4]);
+
+        // 全ての行が失われていないこと（original側はremoved1行+unchanged1行=2）
+        expect(result.filter(p => p.original !== null)).toHaveLength(2);
+        expect(result.filter(p => p.modified !== null)).toHaveLength(4);
+      });
+
+      it('複数の変更ブロックが混在していても左右カラムとも単調増加を維持する', () => {
+        const lines: DiffLine[] = [
+          { lineNumber: 1, content: 'unchanged 1', type: 'unchanged', originalLineNumber: 1, newLineNumber: 1 },
+          { lineNumber: 2, content: 'foo old', type: 'removed', originalLineNumber: 2 },
+          { lineNumber: 3, content: 'bar old', type: 'removed', originalLineNumber: 3 },
+          { lineNumber: 4, content: 'bar new', type: 'added', newLineNumber: 2 },
+          { lineNumber: 5, content: 'foo new', type: 'added', newLineNumber: 3 },
+          { lineNumber: 6, content: 'unchanged 2', type: 'unchanged', originalLineNumber: 4, newLineNumber: 4 },
+          { lineNumber: 7, content: 'baz old', type: 'removed', originalLineNumber: 5 },
+          { lineNumber: 8, content: 'baz new', type: 'added', newLineNumber: 5 },
+          { lineNumber: 9, content: 'qux new only', type: 'added', newLineNumber: 6 },
+          { lineNumber: 10, content: 'unchanged 3', type: 'unchanged', originalLineNumber: 6, newLineNumber: 7 },
+        ];
+        const result = LinePairingService.pairLinesForSideBySide(lines, false);
+
+        expectMonotonicLineNumbers(result);
+      });
+    });
   });
 
   // ========================================
-  // 両アルゴリズムでのクロステスト
+  // matchBlockLinesの基本動作（旧: 両アルゴリズムでのクロステスト）
   // ========================================
-  describe('両アルゴリズムでの動作検証', () => {
-    const algorithms: MatchingAlgorithm[] = ['greedy', 'recursive'];
-
-    let originalAlgorithm: MatchingAlgorithm;
-
-    beforeEach(() => {
-      originalAlgorithm = LinePairingService.getAlgorithm();
+  // 注: 以前はここで 'greedy'/'recursive' を切り替えて同一挙動を確認していたが、
+  // #120 の修正でアルゴリズム切り替えAPI自体が撤去されたため、単一の実装として検証する。
+  describe('matchBlockLinesの基本動作', () => {
+    it('完全一致ペアをマッチング', () => {
+      const lines: DiffLine[] = [
+        createLine('興和株式会社', 'removed', 1),
+        createLine('興和株式会社', 'added', 2),
+      ];
+      const result = LinePairingService.pairLinesForSideBySide(lines, false);
+      expect(result).toHaveLength(1);
+      expect(result[0].original?.line.content).toBe('興和株式会社');
+      expect(result[0].modified?.line.content).toBe('興和株式会社');
     });
 
-    afterEach(() => {
-      LinePairingService.setAlgorithm(originalAlgorithm);
+    it('複数行の順序を保持', () => {
+      const lines: DiffLine[] = [
+        createLine('A', 'removed', 1),
+        createLine('B', 'removed', 2),
+        createLine('C', 'removed', 3),
+        createLine('A', 'added', 4),
+        createLine('B', 'added', 5),
+        createLine('C', 'added', 6),
+      ];
+      const result = LinePairingService.pairLinesForSideBySide(lines, false);
+
+      expect(result).toHaveLength(3);
+      expect(result[0].original?.line.content).toBe('A');
+      expect(result[0].modified?.line.content).toBe('A');
+      expect(result[1].original?.line.content).toBe('B');
+      expect(result[1].modified?.line.content).toBe('B');
+      expect(result[2].original?.line.content).toBe('C');
+      expect(result[2].modified?.line.content).toBe('C');
     });
 
-    algorithms.forEach((algorithm) => {
-      describe(`${algorithm}アルゴリズム`, () => {
-        beforeEach(() => {
-          LinePairingService.setAlgorithm(algorithm);
-        });
+    it('空行を含むブロック', () => {
+      const lines: DiffLine[] = [
+        createLine('興和株式会社', 'removed', 1),
+        createLine('', 'removed', 2),
+        createLine('橋本様', 'removed', 3),
+        createLine('興和株式会社', 'added', 4),
+        createLine('橋本様', 'added', 5),
+      ];
+      const result = LinePairingService.pairLinesForSideBySide(lines, false);
 
-        it('完全一致ペアをマッチング', () => {
-          const lines: DiffLine[] = [
-            createLine('興和株式会社', 'removed', 1),
-            createLine('興和株式会社', 'added', 2),
-          ];
-          const result = LinePairingService.pairLinesForSideBySide(lines, false);
-          expect(result).toHaveLength(1);
-          expect(result[0].original?.line.content).toBe('興和株式会社');
-          expect(result[0].modified?.line.content).toBe('興和株式会社');
-        });
+      const matchedPairs = result.filter(
+        p => p.original && p.modified &&
+             p.original.line.content === p.modified.line.content
+      );
+      expect(matchedPairs.length).toBe(2);
+    });
 
-        it('複数行の順序を保持', () => {
-          const lines: DiffLine[] = [
-            createLine('A', 'removed', 1),
-            createLine('B', 'removed', 2),
-            createLine('C', 'removed', 3),
-            createLine('A', 'added', 4),
-            createLine('B', 'added', 5),
-            createLine('C', 'added', 6),
-          ];
-          const result = LinePairingService.pairLinesForSideBySide(lines, false);
+    it('パフォーマンス（50行）', () => {
+      const lines: DiffLine[] = [];
+      for (let i = 0; i < 50; i++) {
+        lines.push(createLine(`line ${i}`, 'removed', i + 1));
+      }
+      for (let i = 0; i < 50; i++) {
+        lines.push(createLine(`line ${i}`, 'added', i + 51));
+      }
 
-          expect(result).toHaveLength(3);
-          expect(result[0].original?.line.content).toBe('A');
-          expect(result[0].modified?.line.content).toBe('A');
-          expect(result[1].original?.line.content).toBe('B');
-          expect(result[1].modified?.line.content).toBe('B');
-          expect(result[2].original?.line.content).toBe('C');
-          expect(result[2].modified?.line.content).toBe('C');
-        });
+      const startTime = Date.now();
+      const result = LinePairingService.pairLinesForSideBySide(lines, false);
+      const endTime = Date.now();
 
-        it('空行を含むブロック', () => {
-          const lines: DiffLine[] = [
-            createLine('興和株式会社', 'removed', 1),
-            createLine('', 'removed', 2),
-            createLine('橋本様', 'removed', 3),
-            createLine('興和株式会社', 'added', 4),
-            createLine('橋本様', 'added', 5),
-          ];
-          const result = LinePairingService.pairLinesForSideBySide(lines, false);
-
-          const matchedPairs = result.filter(
-            p => p.original && p.modified &&
-                 p.original.line.content === p.modified.line.content
-          );
-          expect(matchedPairs.length).toBe(2);
-        });
-
-        it('パフォーマンス（50行）', () => {
-          const lines: DiffLine[] = [];
-          for (let i = 0; i < 50; i++) {
-            lines.push(createLine(`line ${i}`, 'removed', i + 1));
-          }
-          for (let i = 0; i < 50; i++) {
-            lines.push(createLine(`line ${i}`, 'added', i + 51));
-          }
-
-          const startTime = Date.now();
-          const result = LinePairingService.pairLinesForSideBySide(lines, false);
-          const endTime = Date.now();
-
-          expect(endTime - startTime).toBeLessThan(500);
-          expect(result.length).toBe(50);  // All should match
-        });
-      });
+      expect(endTime - startTime).toBeLessThan(500);
+      expect(result.length).toBe(50);  // All should match
     });
   });
 });

--- a/src/services/linePairingService.ts
+++ b/src/services/linePairingService.ts
@@ -1,33 +1,13 @@
 import type { DiffLine, LineWithSegments, LinePair, SideBySideRow, CollapsedBlock, UnifiedRow, UnifiedCollapsedBlock } from '../types/types';
 import { CharDiffService } from './charDiffService';
 
-/** Matching algorithm type */
-export type MatchingAlgorithm = 'greedy' | 'recursive';
-
 /**
  * Service for pairing removed/added lines in diff views
  * Extracts common pairing logic used by both screen display and HTML export
  */
 export class LinePairingService {
-  /** Current matching algorithm (can be changed at runtime) */
-  private static currentAlgorithm: MatchingAlgorithm = 'greedy';
-
   /** Similarity threshold for matching (0-1) */
   private static similarityThreshold = 0.5;
-
-  /**
-   * Set the matching algorithm
-   */
-  static setAlgorithm(algorithm: MatchingAlgorithm): void {
-    this.currentAlgorithm = algorithm;
-  }
-
-  /**
-   * Get the current matching algorithm
-   */
-  static getAlgorithm(): MatchingAlgorithm {
-    return this.currentAlgorithm;
-  }
 
   /**
    * Set the similarity threshold for matching
@@ -82,53 +62,6 @@ export class LinePairingService {
     const distance = matrix[a.length][b.length];
     const maxLen = Math.max(a.length, b.length);
     return 1 - distance / maxLen;
-  }
-
-  /**
-   * Match removed and added lines by content similarity (Greedy algorithm)
-   * Returns optimal pairings where similar content is aligned
-   */
-  private static matchByContentGreedy(
-    removedLines: DiffLine[],
-    addedLines: DiffLine[]
-  ): { removedIdx: number; addedIdx: number }[] {
-    if (removedLines.length === 0 || addedLines.length === 0) {
-      return [];
-    }
-
-    // Calculate similarity matrix (skip context-less lines as match anchors)
-    const scores: { removedIdx: number; addedIdx: number; score: number }[] = [];
-    for (let i = 0; i < removedLines.length; i++) {
-      if (this.isContextlessLine(removedLines[i].content)) continue;
-      for (let j = 0; j < addedLines.length; j++) {
-        if (this.isContextlessLine(addedLines[j].content)) continue;
-        const score = this.calculateSimilarity(
-          removedLines[i].content,
-          addedLines[j].content
-        );
-        if (score >= this.similarityThreshold) {
-          scores.push({ removedIdx: i, addedIdx: j, score });
-        }
-      }
-    }
-
-    // Sort by score descending (best matches first)
-    scores.sort((a, b) => b.score - a.score);
-
-    // Greedily assign best matches
-    const usedRemoved = new Set<number>();
-    const usedAdded = new Set<number>();
-    const matches: { removedIdx: number; addedIdx: number }[] = [];
-
-    for (const { removedIdx, addedIdx } of scores) {
-      if (!usedRemoved.has(removedIdx) && !usedAdded.has(addedIdx)) {
-        matches.push({ removedIdx, addedIdx });
-        usedRemoved.add(removedIdx);
-        usedAdded.add(addedIdx);
-      }
-    }
-
-    return matches;
   }
 
   /**
@@ -212,18 +145,6 @@ export class LinePairingService {
     return [...beforeMatches, currentMatch, ...afterMatches];
   }
 
-  /**
-   * Match removed and added lines using the selected algorithm
-   */
-  private static matchByContent(
-    removedLines: DiffLine[],
-    addedLines: DiffLine[]
-  ): { removedIdx: number; addedIdx: number }[] {
-    if (this.currentAlgorithm === 'recursive') {
-      return this.matchByContentRecursive(removedLines, addedLines);
-    }
-    return this.matchByContentGreedy(removedLines, addedLines);
-  }
   /**
    * Unified view pairing - finds removed/added blocks and pairs by position
    *
@@ -456,92 +377,25 @@ export class LinePairingService {
       i++;
     }
 
-    // Second pass: try to match remaining unmatched lines globally
-    return this.rematchUnpairedLines(pairs, enableCharDiff);
-  }
-
-  /**
-   * Second pass: find unmatched removed/added lines and try to match them globally
-   * This handles cases where similar lines are separated by unchanged lines
-   */
-  private static rematchUnpairedLines(
-    pairs: LinePair[],
-    enableCharDiff: boolean
-  ): LinePair[] {
-    // Find indices of unmatched lines, excluding context-less lines from remote matching
-    const unmatchedRemovedIndices: number[] = [];
-    const unmatchedAddedIndices: number[] = [];
-
-    pairs.forEach((pair, index) => {
-      if (pair.original && !pair.modified && pair.original.line.type === 'removed' &&
-          !this.isContextlessLine(pair.original.line.content)) {
-        unmatchedRemovedIndices.push(index);
-      }
-      if (pair.modified && !pair.original && pair.modified.line.type === 'added' &&
-          !this.isContextlessLine(pair.modified.line.content)) {
-        unmatchedAddedIndices.push(index);
-      }
-    });
-
-    // If no unmatched lines on both sides, nothing to do
-    if (unmatchedRemovedIndices.length === 0 || unmatchedAddedIndices.length === 0) {
-      return pairs;
-    }
-
-    // Try to find matches among unmatched lines
-    const removedLines = unmatchedRemovedIndices.map(i => pairs[i].original!.line);
-    const addedLines = unmatchedAddedIndices.map(i => pairs[i].modified!.line);
-
-    const matches = this.matchByContent(removedLines, addedLines);
-
-    if (matches.length === 0) {
-      return pairs;
-    }
-
-    // Create new pairs array with matched lines combined
-    const result = [...pairs];
-    const indicesToRemove = new Set<number>();
-
-    for (const { removedIdx, addedIdx } of matches) {
-      const removedPairIndex = unmatchedRemovedIndices[removedIdx];
-      const addedPairIndex = unmatchedAddedIndices[addedIdx];
-
-      const removedLine = pairs[removedPairIndex].original!.line;
-      const addedLine = pairs[addedPairIndex].modified!.line;
-
-      // Update the removed pair to include the matched added line
-      if (enableCharDiff && CharDiffService.shouldShowCharDiff(removedLine.content, addedLine.content)) {
-        const { originalSegments, modifiedSegments } = CharDiffService.calculateCharDiff(
-          removedLine.content,
-          addedLine.content
-        );
-        result[removedPairIndex] = {
-          original: { line: removedLine, segments: originalSegments },
-          modified: { line: addedLine, segments: modifiedSegments }
-        };
-      } else {
-        result[removedPairIndex] = {
-          original: { line: removedLine },
-          modified: { line: addedLine }
-        };
-      }
-
-      // Mark the added pair for removal
-      indicesToRemove.add(addedPairIndex);
-    }
-
-    // Remove the now-redundant added pairs (in reverse order to maintain indices)
-    const sortedIndicesToRemove = Array.from(indicesToRemove).sort((a, b) => b - a);
-    for (const index of sortedIndicesToRemove) {
-      result.splice(index, 1);
-    }
-
-    return result;
+    // Note (#120): a second "rematch across unchanged lines" pass used to run here.
+    // It moved added/removed lines past unchanged rows to combine them into a
+    // single row, which broke the monotonic line-number invariant of each column
+    // (see matchBlockLines below for the current, order-preserving approach).
+    // That pass has been removed entirely; unpaired lines stay at their own
+    // position, one-sided, instead of being relocated.
+    return pairs;
   }
 
   /**
    * Match removed and added lines within a change block
-   * Uses content similarity for better alignment, with interleaving for unmatched lines
+   *
+   * Uses matchByContentRecursive (divide-and-conquer, diff2html style) to find
+   * removed<->added matches. That algorithm only ever returns matches whose
+   * removedIdx and addedIdx both increase together (non-crossing), so merging
+   * them positionally - emitting any unmatched lines that fall strictly before
+   * a match, then the match itself - can never reorder a line relative to its
+   * neighbors within the block. This fixes #120 (right column order being
+   * scrambled by the previous greedy, crossing-prone matching).
    */
   private static matchBlockLines(
     removedLines: DiffLine[],
@@ -569,49 +423,77 @@ export class LinePairingService {
       return pairs;
     }
 
-    // Use content-based matching for reordering similar lines
-    const matches = this.matchByContent(removedLines, addedLines);
+    // Order-preserving (non-crossing) matches only
+    const matches = this.matchByContentRecursive(removedLines, addedLines);
 
-    // Create index mappings for matched pairs
-    const removedToAdded = new Map<number, number>();
-    const addedToRemoved = new Map<number, number>();
+    let removedPos = 0;
+    let addedPos = 0;
 
     for (const { removedIdx, addedIdx } of matches) {
-      removedToAdded.set(removedIdx, addedIdx);
-      addedToRemoved.set(addedIdx, removedIdx);
-    }
+      // Emit the unmatched gap that precedes this match, paired positionally
+      // (this keeps equal-length dissimilar blocks side-by-side, like a plain
+      // position-based diff, without crossing the surrounding content matches)
+      this.emitPositionalGap(
+        removedLines.slice(removedPos, removedIdx),
+        addedLines.slice(addedPos, addedIdx),
+        enableCharDiff,
+        pairs
+      );
 
-    // Track which lines have been output
-    const usedAdded = new Set<number>();
-
-    // Positional index for fallback pairing of unmatched lines
-    let nextUnmatchedAddedIdx = 0;
-
-    // Process removed lines in order
-    for (let removedIdx = 0; removedIdx < removedLines.length; removedIdx++) {
       const removed = removedLines[removedIdx];
+      const added = addedLines[addedIdx];
 
-      // Check for content-similarity match first
-      let added: DiffLine | undefined;
-      if (removedToAdded.has(removedIdx)) {
-        const addedIdx = removedToAdded.get(removedIdx)!;
-        added = addedLines[addedIdx];
-        usedAdded.add(addedIdx);
+      if (enableCharDiff && CharDiffService.shouldShowCharDiff(removed.content, added.content)) {
+        const { originalSegments, modifiedSegments } = CharDiffService.calculateCharDiff(
+          removed.content,
+          added.content
+        );
+        pairs.push({
+          original: { line: removed, segments: originalSegments },
+          modified: { line: added, segments: modifiedSegments }
+        });
       } else {
-        // Fallback: pair positionally with next unused added line
-        while (nextUnmatchedAddedIdx < addedLines.length &&
-               (usedAdded.has(nextUnmatchedAddedIdx) || addedToRemoved.has(nextUnmatchedAddedIdx))) {
-          nextUnmatchedAddedIdx++;
-        }
-        if (nextUnmatchedAddedIdx < addedLines.length) {
-          added = addedLines[nextUnmatchedAddedIdx];
-          usedAdded.add(nextUnmatchedAddedIdx);
-          nextUnmatchedAddedIdx++;
-        }
+        pairs.push({
+          original: { line: removed },
+          modified: { line: added }
+        });
       }
 
-      if (added) {
-        // Output matched pair with char diff if applicable
+      removedPos = removedIdx + 1;
+      addedPos = addedIdx + 1;
+    }
+
+    // Emit the trailing gap after the last match (or the whole block, if no
+    // content match was found at all)
+    this.emitPositionalGap(
+      removedLines.slice(removedPos),
+      addedLines.slice(addedPos),
+      enableCharDiff,
+      pairs
+    );
+
+    return pairs;
+  }
+
+  /**
+   * Emit a positional (index-by-index) pairing for a contiguous "gap" of
+   * removed/added lines that has no content-similarity match on either side
+   * (or has none left to match against). Pairing is purely by position, so it
+   * can never reorder lines relative to each other - it only ever pushes onto
+   * the end of `pairs`, in the gap's own left-to-right order.
+   */
+  private static emitPositionalGap(
+    removedGap: DiffLine[],
+    addedGap: DiffLine[],
+    enableCharDiff: boolean,
+    pairs: LinePair[]
+  ): void {
+    const maxLen = Math.max(removedGap.length, addedGap.length);
+    for (let k = 0; k < maxLen; k++) {
+      const removed = removedGap[k];
+      const added = addedGap[k];
+
+      if (removed && added) {
         if (enableCharDiff && CharDiffService.shouldShowCharDiff(removed.content, added.content)) {
           const { originalSegments, modifiedSegments } = CharDiffService.calculateCharDiff(
             removed.content,
@@ -622,25 +504,14 @@ export class LinePairingService {
             modified: { line: added, segments: modifiedSegments }
           });
         } else {
-          pairs.push({
-            original: { line: removed },
-            modified: { line: added }
-          });
+          pairs.push({ original: { line: removed }, modified: { line: added } });
         }
-      } else {
-        // No added line available - output removed line alone
+      } else if (removed) {
         pairs.push({ original: { line: removed }, modified: null });
+      } else if (added) {
+        pairs.push({ original: null, modified: { line: added } });
       }
     }
-
-    // Output remaining added lines that weren't paired
-    for (let addedIdx = 0; addedIdx < addedLines.length; addedIdx++) {
-      if (!usedAdded.has(addedIdx)) {
-        pairs.push({ original: null, modified: { line: addedLines[addedIdx] } });
-      }
-    }
-
-    return pairs;
   }
 
   /**


### PR DESCRIPTION
## 概要

side-by-side 表示で、変更後（右カラム）の行番号が単調増加にならず、ドキュメントのブロックが入れ替わって表示されるバグの修正。

Closes #120

## 原因

- `matchByContentGreedy` がスコア降順の割り当てのみで順序保存（non-crossing）制約を持たず、交差マッチがそのまま右カラムの順序入れ替わりになっていた
- `rematchUnpairedLines`（第2パス）が unchanged 行を跨いで added 行を removed 行の位置へ移動し、右カラムの行順を大きく崩していた（実例: 129 行 vs 213 行の Markdown 比較で右カラムが `1..86, 152..158, 87..151, 159..` の順に表示）

## 変更内容

- 類似マッチを順序保存の `matchByContentRecursive`（既存・無変更）に一本化し、greedy 実装と `matchByContent` ディスパッチャを削除
- `rematchUnpairedLines` を廃止（行の移動はしない。ペアにできない行は片側表示 + 空セル）
- `matchBlockLines` をマッチ列の先頭からの走査 + `emitPositionalGap`（ギャップの位置ベース interleave）で再構築し、**左右カラムとも行番号が単調増加**という不変条件を保証
- 死にコード化した `setAlgorithm` / `getAlgorithm` / `MatchingAlgorithm` を削除（レビュー指摘反映）
- `pairForUnifiedView` / `pairForSideBySideView`（export 用）は無変更

## テスト計画

- [x] 追加ユニットテスト: Issue #120 の最小再現 2 ケース（右カラム 1→2 / 1→2→3→4 の昇順表示）+ 複数変更ブロック混在時の左右カラム単調増加不変条件（修正前の実装で red になることを確認済み）
- [x] `make test` 231 件緑 / `make build`（tsc + vite build）緑
- [x] `make test-e2e`（Docker、CI と同一環境の visual regression）5 件緑
- [x] 実データ検証: バグ報告の実入力（129 行 / 213 行の Markdown）を実アプリに投入し、Playwright で DOM から左右カラムの行番号を全行抽出 → 順序逆転 0 件・行の欠落 0 件・テキスト不一致 0 件を確認（修正前は 6 箇所で順序崩壊）
- [x] コードレビュー実施（500 ケースのランダム fuzz で行の欠落・重複・単調増加の不変条件違反なしを確認）

## 残課題（スコープ外）

- #121 — 閾値境界の `>` / `>=` 不整合（マッチング精度）と大ブロック時の性能劣化（レビューで検出、既存コード由来の非ブロッカー）
