### PR TITLE
fix: 空行アンカーで分断された変更ブロックを跨ぎ類似ペア検出で統合

### DIFF
--- a/src/__tests__/services/diffService.test.ts
+++ b/src/__tests__/services/diffService.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { DiffService } from '../../services/diffService';
-import type { ComparisonOptions } from '../../types/types';
+import { LinePairingService } from '../../services/linePairingService';
+import type { ComparisonOptions, DiffLine } from '../../types/types';
 
 const defaultOptions: ComparisonOptions = {
   sortLines: false,
@@ -116,6 +117,341 @@ describe('DiffService', () => {
       const result = DiffService.calculateDiff(original, modified, defaultOptions);
       expect(result.stats.added).toBe(0);
       expect(result.stats.removed).toBe(0);
+    });
+  });
+
+  describe('calculateDiff - contextless anchor block merge (issue #123 v2)', () => {
+    // 最小再現 v2: 初版より行を長くし、新旧4ペアの類似度が 0.5 以上になるようにした
+    // （初版の短い行は類似度 0.5 未満になり、跨ぎ類似ペアの検証に使えなかった）。
+    const original = [
+      '<aside>',
+      '🕐',
+      '',
+      'T+0 = mainte mode ON time. each gate go/nogo. see child page for detail.',
+      '',
+      '</aside>',
+      '',
+      '- [ ] T+0:00 B8 mainte mode ON (old ALB sorry page, old account auth)',
+      '- [ ] T+0:00 B7 stop old sidekiq and monit process',
+      '- [ ] T+0:05 B3 RDS migrate with cross account script',
+      '- [ ] T+1:50 B8 mainte mode OFF (old ALB cleanup)',
+      '',
+      '# next section',
+    ].join('\n');
+
+    const modified = [
+      '> 🕐 each gate go/nogo. see child page for detail. times are measured.',
+      '',
+      '- [ ] mainte mode ON (old ALB sorry page, old account auth) -- approx 2 min',
+      '- [ ] stop old sidekiq and monit process -- approx 1 min',
+      '- [ ] brand new ASG suspend step for health check',
+      '- [ ] RDS migrate with cross account script -- approx 75 min',
+      '- [ ] more new step one for something',
+      '- [ ] more new step two for something',
+      '- [ ] mainte mode OFF (old ALB cleanup) -- approx 2 min',
+      '- [ ] postcheck cutover script -- approx 5 min',
+      '',
+      '## next section',
+    ].join('\n');
+
+    /** Split DiffLine[] into contiguous change blocks (removed/added runs) separated by unchanged lines. */
+    function changeBlocks(lines: DiffLine[]): DiffLine[][] {
+      const blocks: DiffLine[][] = [];
+      let current: DiffLine[] = [];
+      for (const line of lines) {
+        if (line.type === 'unchanged') {
+          if (current.length > 0) blocks.push(current);
+          current = [];
+        } else {
+          current.push(line);
+        }
+      }
+      if (current.length > 0) blocks.push(current);
+      return blocks;
+    }
+
+    it.each(['jsdiff', 'builtin'] as const)(
+      '旧チェックリスト(4行)と新チェックリスト(8行)が同一の変更ブロックに入る (%s)',
+      (algorithm) => {
+        const result = DiffService.calculateDiff(original, modified, {
+          ...defaultOptions,
+          algorithm,
+        });
+        const blocks = changeBlocks(result.lines);
+
+        const oldChecklistBlock = blocks.find((b) =>
+          b.some((l) => l.content === '- [ ] T+0:00 B8 mainte mode ON (old ALB sorry page, old account auth)')
+        );
+        const newChecklistBlock = blocks.find((b) =>
+          b.some((l) => l.content === '- [ ] mainte mode ON (old ALB sorry page, old account auth) -- approx 2 min')
+        );
+
+        expect(oldChecklistBlock).toBeDefined();
+        expect(newChecklistBlock).toBeDefined();
+        // 修正前は、旧チェックリストは aside 末尾/セクション見出しと同じブロックに、
+        // 新チェックリストは aside 内部テキストと同じブロックに分断されて別々になる。
+        expect(oldChecklistBlock).toBe(newChecklistBlock);
+
+        const removedContents = oldChecklistBlock!.filter((l) => l.type === 'removed').map((l) => l.content);
+        const addedContents = oldChecklistBlock!.filter((l) => l.type === 'added').map((l) => l.content);
+
+        expect(removedContents).toEqual([
+          'T+0 = mainte mode ON time. each gate go/nogo. see child page for detail.',
+          '',
+          '</aside>',
+          '',
+          '- [ ] T+0:00 B8 mainte mode ON (old ALB sorry page, old account auth)',
+          '- [ ] T+0:00 B7 stop old sidekiq and monit process',
+          '- [ ] T+0:05 B3 RDS migrate with cross account script',
+          '- [ ] T+1:50 B8 mainte mode OFF (old ALB cleanup)',
+          '',
+          '# next section',
+        ]);
+        expect(addedContents).toEqual([
+          '- [ ] mainte mode ON (old ALB sorry page, old account auth) -- approx 2 min',
+          '- [ ] stop old sidekiq and monit process -- approx 1 min',
+          '- [ ] brand new ASG suspend step for health check',
+          '- [ ] RDS migrate with cross account script -- approx 75 min',
+          '- [ ] more new step one for something',
+          '- [ ] more new step two for something',
+          '- [ ] mainte mode OFF (old ALB cleanup) -- approx 2 min',
+          '- [ ] postcheck cutover script -- approx 5 min',
+          '',
+          '## next section',
+        ]);
+      }
+    );
+
+    it('先頭の aside 前置きの空行アンカー（跨ぎ類似ペアの範囲外）は降格されずに残る', () => {
+      // 跨ぎ類似ペアは checklist 同士（2番目・3番目の hunk）にのみ存在するため、
+      // 統合範囲はその2 hunk 間のみ。1番目の hunk（aside 前置き）との間の空行アンカーは
+      // 統合範囲の外なので、そのまま unchanged として残るはず。
+      const result = DiffService.calculateDiff(original, modified, defaultOptions);
+      expect(result.stats.unchanged).toBe(1);
+      const firstUnchangedIndex = result.lines.findIndex((l) => l.type === 'unchanged');
+      expect(result.lines[firstUnchangedIndex].content).toBe('');
+    });
+
+    it('LinePairingService でも新旧4ペアが同一行に横並びし文字単位ハイライトが付く（受け入れ条件 v2）', () => {
+      const result = DiffService.calculateDiff(original, modified, {
+        ...defaultOptions,
+        enableCharDiff: true,
+      });
+      const pairs = LinePairingService.pairLinesForSideBySide(result.lines, true);
+
+      const expectedPairs: [string, string][] = [
+        [
+          '- [ ] T+0:00 B8 mainte mode ON (old ALB sorry page, old account auth)',
+          '- [ ] mainte mode ON (old ALB sorry page, old account auth) -- approx 2 min',
+        ],
+        [
+          '- [ ] T+0:00 B7 stop old sidekiq and monit process',
+          '- [ ] stop old sidekiq and monit process -- approx 1 min',
+        ],
+        [
+          '- [ ] T+0:05 B3 RDS migrate with cross account script',
+          '- [ ] RDS migrate with cross account script -- approx 75 min',
+        ],
+        [
+          '- [ ] T+1:50 B8 mainte mode OFF (old ALB cleanup)',
+          '- [ ] mainte mode OFF (old ALB cleanup) -- approx 2 min',
+        ],
+      ];
+
+      for (const [oldContent, newContent] of expectedPairs) {
+        const row = pairs.find((p) => p.original?.line.content === oldContent);
+        expect(row).toBeDefined();
+        expect(row!.modified?.line.content).toBe(newContent);
+        expect(row!.original?.segments).toBeDefined();
+        expect(row!.modified?.segments).toBeDefined();
+      }
+    });
+
+    it('マージ後も左右カラムの行番号は単調増加のまま（issue #120 不変条件）', () => {
+      const result = DiffService.calculateDiff(original, modified, defaultOptions);
+      const origNums = result.lines
+        .map((l) => l.originalLineNumber)
+        .filter((n): n is number => n !== undefined);
+      const newNums = result.lines
+        .map((l) => l.newLineNumber)
+        .filter((n): n is number => n !== undefined);
+
+      for (let i = 1; i < origNums.length; i++) {
+        expect(origNums[i]).toBeGreaterThan(origNums[i - 1]);
+      }
+      for (let i = 1; i < newNums.length; i++) {
+        expect(newNums[i]).toBeGreaterThan(newNums[i - 1]);
+      }
+    });
+
+    it('マージにより行が失われたり重複したりしない（原文/変更後テキストの全行を1回ずつ保持）', () => {
+      const result = DiffService.calculateDiff(original, modified, defaultOptions);
+      const originalLineCount = original.split('\n').length;
+      const modifiedLineCount = modified.split('\n').length;
+
+      expect(result.lines.filter((l) => l.originalLineNumber !== undefined).length).toBe(originalLineCount);
+      expect(result.lines.filter((l) => l.newLineNumber !== undefined).length).toBe(modifiedLineCount);
+    });
+
+    it('前後どちらもcontextlessでない通常のunchanged行はブロックをまたいで結合しない', () => {
+      const original2 = 'foo\nCOMMON\nbar';
+      const modified2 = 'baz\nCOMMON\nqux';
+      const result = DiffService.calculateDiff(original2, modified2, defaultOptions);
+      const blocks = changeBlocks(result.lines);
+      // 'COMMON' は contextless ではない実質的な共通行なので、分断を維持する
+      expect(blocks.length).toBe(2);
+      expect(result.stats.unchanged).toBe(1);
+    });
+
+    it('ファイル先頭がcontextlessな行のみのケースでも安全に処理する', () => {
+      const original3 = '\nfoo';
+      const modified3 = '\nbar';
+      const result = DiffService.calculateDiff(original3, modified3, defaultOptions);
+      // 先頭の空行アンカーは "前のブロック" が存在しないためマージ対象外（そのまま）
+      expect(result.stats.unchanged).toBe(1);
+      expect(result.lines.filter((l) => l.originalLineNumber !== undefined).length).toBe(2);
+      expect(result.lines.filter((l) => l.newLineNumber !== undefined).length).toBe(2);
+    });
+
+    it('跨ぎ類似ペアが存在しない場合（純粋な新規セクション挿入）は統合が発動しない（回帰テスト）', () => {
+      // セクション全体が新規追加されただけで、削除された行が1つも無い（= removed 行が
+      // 存在しない）ため、跨ぎ類似ペアはそもそも成立しようがない。
+      const originalNoOverlap = [
+        'intro line',
+        '',
+        '# Section A',
+        'content a1',
+        'content a2',
+        '',
+        '# Section B',
+        'content b1',
+      ].join('\n');
+      const modifiedNoOverlap = [
+        'intro line',
+        '',
+        '# Section A',
+        'content a1',
+        'content a2',
+        '',
+        '# Section NEW',
+        'brand new content here',
+        '',
+        '# Section B',
+        'content b1',
+      ].join('\n');
+
+      const result = DiffService.calculateDiff(originalNoOverlap, modifiedNoOverlap, defaultOptions);
+
+      expect(result.stats.removed).toBe(0);
+      expect(result.stats.added).toBe(3);
+      // 挿入前後の空行アンカーは、跨ぎ類似ペアが無いので降格されず、そのまま維持される。
+      expect(result.stats.unchanged).toBe(8);
+    });
+
+    it('高い類似ペアが同一hunk内にしか無い場合は「跨ぎ」ではないため統合トリガーにならない', () => {
+      // 各 hunk は単体で見ると removed/added の類似度が高い（= 既に正しくペアリング
+      // されている）が、hunk をまたいだ類似ペアは存在しない。この場合は統合の必要が
+      // ないため、mergeContextlessAnchorBlocks は何もせず、間の空行アンカーは維持される。
+      const originalNoCrossing = ['cat sat on the mat', '', 'unrelated original line here'].join('\n');
+      const modifiedNoCrossing = ['cat sat on the rug', '', 'unrelated modified line totally different'].join(
+        '\n'
+      );
+      const result = DiffService.calculateDiff(originalNoCrossing, modifiedNoCrossing, defaultOptions);
+      const blocks = changeBlocks(result.lines);
+
+      expect(blocks.length).toBe(2);
+      expect(result.stats.unchanged).toBe(1);
+    });
+
+    it('区間の総行数が400行を超える場合は性能ガードで統合をスキップする', () => {
+      // 跨ぎ類似ペア自体は先頭hunkと末尾hunkの間に実在するが、区間の総行数が
+      // 400行を超えるため、統合処理そのものをスキップして分断されたまま残る。
+      const N = 150;
+      const originalLines: string[] = [];
+      const modifiedLines: string[] = [];
+      for (let i = 0; i < N; i++) {
+        originalLines.push(
+          i === 0
+            ? 'the quick brown fox jumps over the lazy dog example line'
+            : `unique original filler content number ${i} alpha beta gamma delta`
+        );
+        originalLines.push('');
+        modifiedLines.push(
+          i === N - 1
+            ? 'the quick brown fox jumps over the lazy dog example line variant'
+            : `different modified filler payload number ${i} epsilon zeta eta theta`
+        );
+        modifiedLines.push('');
+      }
+
+      const result = DiffService.calculateDiff(originalLines.join('\n'), modifiedLines.join('\n'), defaultOptions);
+      const blocks = changeBlocks(result.lines);
+
+      const firstBlock = blocks.find((b) =>
+        b.some((l) => l.type === 'removed' && l.content.includes('the quick brown fox jumps over the lazy dog example line') && !l.content.includes('variant'))
+      );
+      const lastBlock = blocks.find((b) =>
+        b.some((l) => l.type === 'added' && l.content.includes('the quick brown fox jumps over the lazy dog example line variant'))
+      );
+
+      expect(firstBlock).toBeDefined();
+      expect(lastBlock).toBeDefined();
+      // 400行ガードにより統合されず、別ブロックのまま。
+      expect(firstBlock).not.toBe(lastBlock);
+    });
+
+    it('統合範囲内の無関係な中間 hunk も一緒に統合される（MEDIUM指摘の回帰テスト）', () => {
+      // H0(removed のみ) - anchor - H1(自己完結した無関係な置換) - anchor - H2(added のみ)
+      // という3 hunk 構成。跨ぎ類似ペアは H0 の removed と H2 の added の間にしか無いが、
+      // 統合範囲は「跨ぎ類似ペアを全て包含する最小の連続 hunk 範囲」= [H0, H2] であるため、
+      // それ自体は跨ぎペアの根拠を持たず自己完結して正しくペアリングできていた H1
+      // （cat sat on the mat/rug）も統合対象に巻き込まれ、前後のアンカーが降格される。
+      // これは仕様どおりの意図した挙動（最小"連続"範囲）であり、回帰を防止するために固定する。
+      const original = [
+        'the quick brown fox jumps over the lazy dog for testing similarity',
+        '',
+        'cat sat on the mat',
+        '',
+        'totally unrelated old bottom text www',
+      ].join('\n');
+      const modified = [
+        'totally unrelated new top text zzz',
+        '',
+        'cat sat on the rug',
+        '',
+        'the quick brown fox jumps over the lazy dog for testing similarity updated',
+      ].join('\n');
+
+      const result = DiffService.calculateDiff(original, modified, defaultOptions);
+      const blocks = changeBlocks(result.lines);
+
+      // 中間の自己完結hunk（cat sat on the mat/rug）を含め、全体が単一ブロックに統合される。
+      expect(blocks.length).toBe(1);
+      const mergedBlock = blocks[0];
+      expect(mergedBlock.some((l) => l.type === 'removed' && l.content === 'cat sat on the mat')).toBe(true);
+      expect(mergedBlock.some((l) => l.type === 'added' && l.content === 'cat sat on the rug')).toBe(true);
+      // 前後のアンカー（空行）も降格され、unchanged は残らない。
+      expect(result.stats.unchanged).toBe(0);
+
+      // 行の欠落・重複がないこと（原文5行・変更後5行がそれぞれちょうど1回ずつ現れる）。
+      const originalLineCount = original.split('\n').length;
+      const modifiedLineCount = modified.split('\n').length;
+      expect(result.lines.filter((l) => l.originalLineNumber !== undefined).length).toBe(originalLineCount);
+      expect(result.lines.filter((l) => l.newLineNumber !== undefined).length).toBe(modifiedLineCount);
+
+      // 左右カラムの行番号単調増加が保たれること（issue #120 不変条件）。
+      const origNums = result.lines
+        .map((l) => l.originalLineNumber)
+        .filter((n): n is number => n !== undefined);
+      const newNums = result.lines
+        .map((l) => l.newLineNumber)
+        .filter((n): n is number => n !== undefined);
+      for (let i = 1; i < origNums.length; i++) {
+        expect(origNums[i]).toBeGreaterThan(origNums[i - 1]);
+      }
+      for (let i = 1; i < newNums.length; i++) {
+        expect(newNums[i]).toBeGreaterThan(newNums[i - 1]);
+      }
     });
   });
 });

--- a/src/services/diffService.ts
+++ b/src/services/diffService.ts
@@ -65,6 +65,15 @@ export class DiffService {
       ? this.calculateDiffWithJsDiff(processedOriginal, processedModified)
       : this.calculateDiffWithBuiltin(processedOriginal, processedModified);
 
+    // Fix contextless-anchor block fragmentation (#123) unconditionally: this is
+    // a correctness fix for anchor selection, not an optional heuristic, so it
+    // always runs regardless of algorithm choice.
+    const mergedLines = this.mergeContextlessAnchorBlocks(result.lines);
+    if (mergedLines !== result.lines) {
+      const renumbered = this.reassignLineNumbers(mergedLines);
+      result = { lines: renumbered, stats: this.calculateStats(renumbered) };
+    }
+
     if (options?.indentHeuristic) {
       const heuristicLines = this.applyIndentHeuristic(result.lines);
       const heuristicStats = this.calculateStats(heuristicLines);
@@ -318,6 +327,244 @@ export class DiffService {
 
     return stats
   }
+
+  // ── Contextless Anchor Block Merge (#123, v2) ───────────────────────────────
+  //
+  // Problem: when the only common lines between a removed run and an added run
+  // are "contextless" ones (blank lines, or lines that are only structural
+  // characters like `{}();,`), Myers/jsdiff can anchor on an arbitrary interior
+  // occurrence of that contextless content (e.g. a blank line *inside* an
+  // unrelated block) instead of the occurrence that actually borders the real
+  // change. That splits one logical change into two unrelated change blocks,
+  // so line-pairing (which only matches within a single block) can no longer
+  // line up the corresponding edited lines.
+  //
+  // v1 (superseded): relocated contextless anchors to the tail of their
+  // surrounding region while trying to preserve the total anchor count. That
+  // over-triggered on large documents where most sections are separated only
+  // by blank lines, pairing up unrelated sections. Replaced by v2 below.
+  //
+  // Fix v2 (issue #123 revision): only demote a contextless anchor run when
+  // there is *evidence* that it is splitting a single logical change in two -
+  // i.e. a "crossing similar pair": a removed line in one hunk and an added
+  // line in a *different* hunk of the same contextless-anchor-delimited
+  // region, with calculateSimilarity >= 0.5 (contextless lines themselves
+  // never count as candidates). If no such pair exists, the region is left
+  // untouched (e.g. a plain new-section insertion stays split, as before).
+  // When a crossing pair is found, the minimal contiguous hunk range that
+  // covers *all* crossing pairs is merged into a single change block by
+  // demoting (removed+added) every contextless anchor strictly inside that
+  // range; anchors outside the range are untouched. The former "preserve the
+  // anchor/match count" constraint from v1 is intentionally dropped: an
+  // unmatched contextless anchor carries no information, so pairing the real
+  // content is worth more than keeping it 'unchanged'.
+
+  /** Similarity threshold for the "crossing pair" trigger check (issue #123 v2). */
+  private static readonly CROSSING_PAIR_SIMILARITY_THRESHOLD = 0.5;
+
+  /** Performance guard: skip merge attempts for regions larger than this many lines. */
+  private static readonly MAX_MERGE_REGION_LINES = 400;
+
+  /** contextless = blank, or only structural characters (`{}();,`). */
+  private static isContextlessAnchorContent(content: string): boolean {
+    const trimmed = content.trim();
+    if (trimmed.length === 0) return true;
+    return /^[{}()[\];,]+$/.test(trimmed);
+  }
+
+  /**
+   * Similarity between two strings (0-1), Levenshtein-distance based.
+   * Intentional duplicate of LinePairingService.calculateSimilarity: per the
+   * issue #123 brief, linePairingService.ts is left untouched, so diffService
+   * keeps its own copy of this small, self-contained helper.
+   */
+  private static calculateLineSimilarity(a: string, b: string): number {
+    if (a === b) return 1;
+    if (a.length === 0 || b.length === 0) return 0;
+
+    const matrix: number[][] = [];
+    for (let i = 0; i <= a.length; i++) matrix[i] = [i];
+    for (let j = 0; j <= b.length; j++) matrix[0][j] = j;
+    for (let i = 1; i <= a.length; i++) {
+      for (let j = 1; j <= b.length; j++) {
+        const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+        matrix[i][j] = Math.min(
+          matrix[i - 1][j] + 1,
+          matrix[i][j - 1] + 1,
+          matrix[i - 1][j - 1] + cost
+        );
+      }
+    }
+    const distance = matrix[a.length][b.length];
+    const maxLen = Math.max(a.length, b.length);
+    return 1 - distance / maxLen;
+  }
+
+  private static isFullyContextlessSegment(lines: DiffLine[]): boolean {
+    return lines.length > 0 && lines.every(l => this.isContextlessAnchorContent(l.content));
+  }
+
+  /**
+   * Entry point: scan the flat DiffLine[] for hunk/anchor segments and, within
+   * each maximal chain of hunks separated solely by fully-contextless anchors,
+   * demote the anchors that split a genuine cross-hunk edit (see header
+   * comment above). Returns the same array reference when nothing changes.
+   */
+  private static mergeContextlessAnchorBlocks(lines: DiffLine[]): DiffLine[] {
+    if (lines.length === 0) return lines;
+
+    type Segment = { isAnchor: boolean; lines: DiffLine[] };
+    const segments: Segment[] = [];
+    {
+      let i = 0;
+      while (i < lines.length) {
+        const isAnchor = lines[i].type === 'unchanged';
+        const start = i;
+        while (i < lines.length && (lines[i].type === 'unchanged') === isAnchor) i++;
+        segments.push({ isAnchor, lines: lines.slice(start, i) });
+      }
+    }
+
+    const result: DiffLine[] = [];
+    let changed = false;
+    let s = 0;
+
+    while (s < segments.length) {
+      if (segments[s].isAnchor) {
+        // Leading/standalone anchor run: nothing to merge it into on the left.
+        result.push(...segments[s].lines);
+        s++;
+        continue;
+      }
+
+      // segments[s] is a hunk. Extend as far as alternating
+      // (contextless anchor, hunk) pairs allow.
+      let e = s;
+      while (
+        e + 2 < segments.length &&
+        this.isFullyContextlessSegment(segments[e + 1].lines)
+      ) {
+        e += 2;
+      }
+
+      if (e === s) {
+        result.push(...segments[s].lines);
+        s++;
+        continue;
+      }
+
+      const region = segments.slice(s, e + 1);
+      const rebuilt = this.demoteContextlessAnchorsForCrossingPairs(region);
+      if (rebuilt === null) {
+        // No crossing similar pair found (or region too large) - leave untouched.
+        for (const seg of region) result.push(...seg.lines);
+      } else {
+        result.push(...rebuilt);
+        changed = true;
+      }
+      s = e + 1;
+    }
+
+    return changed ? result : lines;
+  }
+
+  /**
+   * Within a [hunk, contextless-anchor, hunk, contextless-anchor, ..., hunk]
+   * region, look for a "crossing similar pair": a non-contextless removed line
+   * in one hunk and a non-contextless added line in a *different* hunk of the
+   * same region, with calculateSimilarity >= CROSSING_PAIR_SIMILARITY_THRESHOLD.
+   *
+   * Returns null when:
+   *  - the region exceeds MAX_MERGE_REGION_LINES (performance guard), or
+   *  - no crossing similar pair exists (nothing to merge; leave as-is).
+   *
+   * Otherwise, returns the region rebuilt so that the minimal contiguous hunk
+   * range covering every crossing pair becomes a single change block (all
+   * interior contextless anchors demoted to removed+added); anchors outside
+   * that range are left untouched.
+   */
+  private static demoteContextlessAnchorsForCrossingPairs(
+    segments: { isAnchor: boolean; lines: DiffLine[] }[]
+  ): DiffLine[] | null {
+    const totalLines = segments.reduce((sum, seg) => sum + seg.lines.length, 0);
+    if (totalLines > this.MAX_MERGE_REGION_LINES) {
+      return null;
+    }
+
+    // Hunks live at even segment indices (0, 2, 4, ...); anchors at odd ones.
+    const hunkSegmentIndices: number[] = [];
+    for (let idx = 0; idx < segments.length; idx += 2) hunkSegmentIndices.push(idx);
+
+    const removedCandidates: { hunkIdx: number; line: DiffLine }[] = [];
+    const addedCandidates: { hunkIdx: number; line: DiffLine }[] = [];
+
+    hunkSegmentIndices.forEach((segIdx, hunkIdx) => {
+      for (const line of segments[segIdx].lines) {
+        if (this.isContextlessAnchorContent(line.content)) continue;
+        if (line.type === 'removed') removedCandidates.push({ hunkIdx, line });
+        else if (line.type === 'added') addedCandidates.push({ hunkIdx, line });
+      }
+    });
+
+    let minHunkIdx = -1;
+    let maxHunkIdx = -1;
+
+    for (const r of removedCandidates) {
+      for (const a of addedCandidates) {
+        if (r.hunkIdx === a.hunkIdx) continue; // same hunk - not a "crossing" pair
+        if (
+          this.calculateLineSimilarity(r.line.content, a.line.content) >=
+          this.CROSSING_PAIR_SIMILARITY_THRESHOLD
+        ) {
+          const lo = Math.min(r.hunkIdx, a.hunkIdx);
+          const hi = Math.max(r.hunkIdx, a.hunkIdx);
+          if (minHunkIdx === -1 || lo < minHunkIdx) minHunkIdx = lo;
+          if (hi > maxHunkIdx) maxHunkIdx = hi;
+        }
+      }
+    }
+
+    if (minHunkIdx === -1) {
+      // No evidence of a split edit in this region; do nothing.
+      return null;
+    }
+
+    // [minHunkIdx, maxHunkIdx] is the minimal contiguous range covering every
+    // crossing pair found above. Any hunk strictly between minHunkIdx and
+    // maxHunkIdx that is *not* itself part of a crossing pair (i.e. an
+    // unrelated, self-contained hunk that was already pairing correctly on
+    // its own) still gets swept into the merged block, and its bordering
+    // contextless anchors still get demoted along with it. This is
+    // intentional (minimal-*contiguous*-range, not "only the exact hunks
+    // involved"): splitting the merge around such a hunk would reintroduce
+    // the anchor-fragmentation problem this fix targets. See the regression
+    // test '統合範囲内の無関係な中間 hunk も一緒に統合される' below.
+    const startSegIdx = hunkSegmentIndices[minHunkIdx];
+    const endSegIdx = hunkSegmentIndices[maxHunkIdx];
+
+    const rebuilt: DiffLine[] = [];
+    for (let idx = 0; idx < startSegIdx; idx++) rebuilt.push(...segments[idx].lines);
+
+    // Flatten the merge range [startSegIdx, endSegIdx] into original/modified
+    // sequences and emit as one removed block followed by one added block,
+    // demoting every contextless anchor inside the range in the process.
+    const origSeq: DiffLine[] = [];
+    const modSeq: DiffLine[] = [];
+    for (let idx = startSegIdx; idx <= endSegIdx; idx++) {
+      for (const line of segments[idx].lines) {
+        if (line.originalLineNumber !== undefined) origSeq.push(line);
+        if (line.newLineNumber !== undefined) modSeq.push(line);
+      }
+    }
+    for (const line of origSeq) rebuilt.push({ ...line, type: 'removed', newLineNumber: undefined });
+    for (const line of modSeq) rebuilt.push({ ...line, type: 'added', originalLineNumber: undefined });
+
+    for (let idx = endSegIdx + 1; idx < segments.length; idx++) rebuilt.push(...segments[idx].lines);
+
+    return rebuilt;
+  }
+
+  // ── End Contextless Anchor Block Merge ──────────────────────────────────────
 
   /**
    * Adjust stats to count char-diff pairs as `modified` instead of separate removed+added.


### PR DESCRIPTION
## 概要

side-by-side 表示で、「同じ行を編集しただけ」の行同士が横並びにならず、削除ブロックと追加ブロックが遠く離れて表示される問題の修正。

Closes #123

## 原因

全行が書き換わったセクション（例: チェックリスト全項目の文言変更 + 項目追加）では diff が内部にアンカーを張れず、周辺の**空行**を共通アンカーに選ぶ。空行はどの空行ともマッチできるため等コストの整列が複数あり、変更ブロックを分断する整列が選ばれると、類似ペアリング（同一変更ブロック内でのみ動作）が働かなくなる。

## 変更内容

diff 後処理 `mergeContextlessAnchorBlocks` を追加:

1. DiffLine 列を hunk（removed/added 連続 run）と anchor（unchanged 連続 run）に分解
2. **contextless 行（空行・構造文字のみ）だけのアンカー**で区切られた hunk 領域を検出
3. 異なる hunk 間に**類似度 0.5 以上の removed×added ペア（跨ぎ類似ペア）**が存在する場合のみ、それらを包含する最小 hunk 範囲を 1 ブロックに統合（間のアンカー行は removed+added に降格）
4. 跨ぎ類似ペアが無い場合（純粋な新規セクション挿入等）は何もしない
5. 性能ガード: 領域総行数 400 超はスキップ

範囲内に位置する無関係な中間 hunk も巻き込まれるのは意図した挙動（最小包含範囲）で、回帰テストで固定済み。

## テスト計画

- [x] `make test` 243 件緑（新規 12 件: 最小再現のブロック統合 jsdiff/builtin 両系・4 ペアの横並び + 文字単位ハイライト・非発動回帰・400 行ガード・中間 hunk 巻き込み・#120 単調増加不変条件の維持・行の欠落/重複なし）
- [x] `make build` 緑 / `make test-e2e`（Docker、CI 同一環境）5 件緑・既存スナップショット変化なし
- [x] 実データ検証（129 行 / 213 行の Markdown・Issue #120/#123 の題材）: 修正前は「メンテモード ON」の新旧ペアが別ブロックに分断 → 修正後は同一行に横並び + 文字単位ハイライト表示をスクリーンショットで確認。全行 DOM 照合で行順逆転 0・欠落 0・テキスト不一致 0
- [x] コードレビュー実施（CRITICAL/HIGH 0。300 ケース fuzz で不変条件検証済み。MEDIUM 1 件は回帰テスト追加で対応済み）
